### PR TITLE
fix: handle nested base URL paths in client-js

### DIFF
--- a/docs/sdk/js.md
+++ b/docs/sdk/js.md
@@ -32,7 +32,7 @@ Configuration is validated at construction time using Zod. If a required field i
 
 | Option             | Type       | Required | Description                                                                                                     |
 | ------------------ | ---------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `url`              | `string`   | ✅       | Base URL of your Logwolf instance, including `/api/`. Must be a valid URL.                                      |
+| `url`              | `string`   | ✅       | Base URL of your Logwolf instance, e.g. `https://your-domain.com/api`. Trailing slash is optional — the client normalises it internally. Must be a valid URL. |
 | `apiKey`           | `string`   | ✅       | API key generated from the dashboard. Must start with `lw_` and be at least 10 characters.                     |
 | `flushIntervalMs`  | `number`   | ✅       | How often (ms) the queue is flushed automatically.                                                              |
 | `maxBatchSize`     | `number`   | ✅       | Flush immediately when the queue reaches this many events, without waiting for the interval.                    |

--- a/logwolf-client/js/lib/client.test.ts
+++ b/logwolf-client/js/lib/client.test.ts
@@ -72,7 +72,7 @@ describe('Logwolf', () => {
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 			expect(mockFetch).toHaveBeenCalledWith(
-				new URL('/logs', testConfig.url),
+				new URL('http://test.url/logs'),
 				expect.objectContaining({ method: 'POST', body: JSON.stringify(ev.toObject()) }),
 			);
 		});
@@ -180,7 +180,7 @@ describe('Logwolf', () => {
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 			expect(mockFetch).toHaveBeenCalledWith(
-				new URL('/logs/batch', testConfig.url),
+				new URL('http://test.url/logs/batch'),
 				expect.objectContaining({ method: 'POST' }),
 			);
 			const body = JSON.parse(mockFetch.mock.calls.at(0)?.at(1).body);
@@ -329,7 +329,7 @@ describe('Logwolf', () => {
 		await client.getAll();
 
 		expect(mockFetch).toHaveBeenCalledWith(
-			new URL('/logs?', testConfig.url),
+			new URL('http://test.url/logs?'),
 			expect.objectContaining({ method: 'GET' }),
 		);
 	});
@@ -340,7 +340,7 @@ describe('Logwolf', () => {
 		await client.delete({ id: 'id' });
 
 		expect(mockFetch).toHaveBeenCalledWith(
-			new URL('/logs', testConfig.url),
+			new URL('http://test.url/logs'),
 			expect.objectContaining({ method: 'DELETE', body: JSON.stringify({ id: 'id' }) }),
 		);
 	});

--- a/logwolf-client/js/lib/client.test.ts
+++ b/logwolf-client/js/lib/client.test.ts
@@ -315,6 +315,14 @@ describe('Logwolf', () => {
 
 	// --- getAll / delete (unchanged) ---
 
+	it('resolves URLs correctly when base URL has a path prefix', async () => {
+		const client = new Logwolf({ ...testConfig, url: 'http://example.com/api' });
+		await client.create(makeEvent());
+
+		const calledUrl: URL = mockFetch.mock.calls.at(0)?.at(0);
+		expect(calledUrl.href).toBe('http://example.com/api/logs');
+	});
+
 	it('gets events correctly', async () => {
 		mockFetch.mockReturnValue(Promise.resolve({ json: vi.fn().mockResolvedValue({ error: false, data: [] }) }));
 		const client = new Logwolf(testConfig);

--- a/logwolf-client/js/lib/client.ts
+++ b/logwolf-client/js/lib/client.ts
@@ -84,7 +84,7 @@ export class Logwolf {
 	 */
 	public async create(event: LogwolfEvent): Promise<void> {
 		event.stop();
-		const url = new URL('/logs', this.baseUrl);
+		const url = new URL('logs', this.baseUrl);
 		const res = await this.fetchWithTimeout(url, {
 			method: 'POST',
 			headers: this.getHeaders(),
@@ -98,7 +98,7 @@ export class Logwolf {
 
 	public async getAll(p?: Pagination): Promise<LogwolfEventData[]> {
 		const params = p ? PaginationSchema.encode(p) : '';
-		const url = new URL('/logs?' + params, this.baseUrl);
+		const url = new URL('logs?' + params, this.baseUrl);
 		const res = await this.fetchWithTimeout(url, { method: 'GET', headers: this.getHeaders() })
 			.then<LogwolfApiResponse<Event[]>>((r) => r.json())
 			.then((r) => this.handleResponse(r));
@@ -111,7 +111,7 @@ export class Logwolf {
 	}
 
 	public async delete(dto: DeleteLogwolfEventDTO): Promise<void> {
-		const url = new URL('/logs', this.baseUrl);
+		const url = new URL('logs', this.baseUrl);
 		const res = await this.fetchWithTimeout(url, {
 			method: 'DELETE',
 			headers: this.getHeaders(),
@@ -200,7 +200,7 @@ export class Logwolf {
 	}
 
 	private async sendBatchWithRetry(batch: LogwolfEvent[]): Promise<void> {
-		const url = new URL('/logs/batch', this.baseUrl);
+		const url = new URL('logs/batch', this.baseUrl);
 		const body = JSON.stringify(batch.map((ev) => ev.toObject()));
 
 		let lastError: unknown;

--- a/logwolf-client/js/lib/client.ts
+++ b/logwolf-client/js/lib/client.ts
@@ -24,8 +24,9 @@ export class Logwolf {
 
 	constructor(config: LogwolfConfig) {
 		this.config = LogwolfConfigSchema.parse(config);
-		// Pre-compute base URL once to avoid repeated allocations per request.
-		this.baseUrl = new URL(this.config.url);
+		// Normalize to a trailing slash so relative paths append correctly.
+		const raw = this.config.url;
+		this.baseUrl = new URL(raw.endsWith('/') ? raw : raw + '/');
 	}
 
 	// --- Private: helpers ---

--- a/logwolf-client/js/package-lock.json
+++ b/logwolf-client/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@logwolf/client-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@logwolf/client-js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "zod": "^4.3.6"

--- a/logwolf-client/js/package.json
+++ b/logwolf-client/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@logwolf/client-js",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "JavaScript client for Logwolf",
 	"keywords": [
 		"logwolf"


### PR DESCRIPTION
## What

Fix URL construction in the JS client so that a base URL with a path prefix (e.g. `http://example.com/api`) correctly resolves endpoint URLs like `/api/logs` instead of stripping the prefix.

## Why

The root cause is a combination of two issues:

1. Paths like `/logs` are *absolute* — `new URL('/logs', 'http://example.com/api')` replaces the entire base path, yielding `http://example.com/logs`.
2. Even switching to a relative path (`logs`) is not enough on its own: `new URL('logs', 'http://example.com/api')` still yields `http://example.com/logs` because the WHATWG URL parser treats `api` as a file segment and replaces it, not appends to it.

The fix requires both changes together:
- **Normalize the base URL** to always end with a trailing slash in the constructor, so the base is treated as a directory.
- **Use relative paths** (`logs`, `logs/batch`) instead of absolute paths (`/logs`, `/logs/batch`), so the resolver appends rather than replaces.

With both in place, `new URL('logs', 'http://example.com/api/')` correctly resolves to `http://example.com/api/logs`.

## Changes

- `logwolf-client/js/lib/client.ts`: normalize `baseUrl` to trailing slash in constructor; change `/logs`, `/logs/batch` → `logs`, `logs/batch` at all four call sites
- `logwolf-client/js/lib/client.test.ts`: add regression test with a prefixed base URL (`http://example.com/api`)
- Bumped `@logwolf/client-js` to `1.1.1`