### PR TITLE
feat(data): make LogEntry and Settings project-scoped

### DIFF
--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -210,10 +210,6 @@ func (app *Config) RevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "Key revoked."})
 }
 
-type retentionPayload struct {
-	Days int `json:"days"`
-}
-
 type retentionResponse struct {
 	Days int `json:"days"`
 }

--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -227,7 +227,8 @@ func (app *Config) GetRetention(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := client.Call("RPCServer.GetRetention", "", &days); err != nil {
+	args := data.RetentionArgs{ProjectID: r.URL.Query().Get("project_id")}
+	if err := client.Call("RPCServer.GetRetention", &args, &days); err != nil {
 		app.errorJSON(w, err)
 		return
 	}
@@ -236,7 +237,10 @@ func (app *Config) GetRetention(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *Config) UpdateRetention(w http.ResponseWriter, r *http.Request) {
-	var payload retentionPayload
+	var payload struct {
+		ProjectID string `json:"project_id"`
+		Days      int    `json:"days"`
+	}
 
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		app.errorJSON(w, err)
@@ -249,8 +253,9 @@ func (app *Config) UpdateRetention(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	args := data.RetentionArgs{ProjectID: payload.ProjectID, Days: payload.Days}
 	var reply string
-	if err := client.Call("RPCServer.UpdateRetention", &payload.Days, &reply); err != nil {
+	if err := client.Call("RPCServer.UpdateRetention", &args, &reply); err != nil {
 		app.errorJSON(w, err)
 		return
 	}

--- a/logwolf-server/logger/cmd/api/main.go
+++ b/logwolf-server/logger/cmd/api/main.go
@@ -46,7 +46,11 @@ func main() {
 		Models: data.New(client),
 	}
 
-	retentionDays, err := app.Models.Settings.GetRetentionDays()
+	if err := app.Models.Settings.EnsureSettingsIndex(); err != nil {
+		log.Printf("Warning: could not ensure settings index: %v", err)
+	}
+
+	retentionDays, err := app.Models.Settings.GetRetentionDays("")
 	if err != nil {
 		log.Printf("Warning: could not read retention setting, using default: %v", err)
 		retentionDays = 90

--- a/logwolf-server/logger/cmd/api/main.go
+++ b/logwolf-server/logger/cmd/api/main.go
@@ -49,6 +49,9 @@ func main() {
 	if err := app.Models.Settings.EnsureSettingsIndex(); err != nil {
 		log.Printf("Warning: could not ensure settings index: %v", err)
 	}
+	if err := app.Models.EnsureLogsIndexes(); err != nil {
+		log.Printf("Warning: could not ensure logs indexes: %v", err)
+	}
 
 	retentionDays, err := app.Models.Settings.GetRetentionDays("")
 	if err != nil {

--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -14,11 +14,12 @@ func (r *RPCServer) LogInfo(p data.RPCLogPayload, resp *string) error {
 	log.Printf("Logging info: %s", p.Name)
 
 	err := r.models.Insert(data.LogEntry{
-		Name:     p.Name,
-		Data:     p.Data,
-		Severity: p.Severity,
-		Tags:     p.Tags,
-		Duration: p.Duration,
+		ProjectID: p.ProjectID,
+		Name:      p.Name,
+		Data:      p.Data,
+		Severity:  p.Severity,
+		Tags:      p.Tags,
+		Duration:  p.Duration,
 	})
 	if err != nil {
 		log.Println("Error inserting into logs:", err)
@@ -61,8 +62,8 @@ func (r *RPCServer) DeleteLog(f data.RPCLogEntryFilter, resp *int64) error {
 	return nil
 }
 
-func (r *RPCServer) GetRetention(args *string, reply *int) error {
-	days, err := r.models.Settings.GetRetentionDays()
+func (r *RPCServer) GetRetention(args *data.RetentionArgs, reply *int) error {
+	days, err := r.models.Settings.GetRetentionDays(args.ProjectID)
 	if err != nil {
 		return err
 	}
@@ -70,11 +71,11 @@ func (r *RPCServer) GetRetention(args *string, reply *int) error {
 	return nil
 }
 
-func (r *RPCServer) UpdateRetention(days *int, reply *string) error {
-	if err := r.models.Settings.SetRetentionDays(*days); err != nil {
+func (r *RPCServer) UpdateRetention(args *data.RetentionArgs, reply *string) error {
+	if err := r.models.Settings.SetRetentionDays(args.ProjectID, args.Days); err != nil {
 		return err
 	}
-	if err := r.models.Settings.EnsureTTLIndex(*days); err != nil {
+	if err := r.models.Settings.EnsureTTLIndex(args.Days); err != nil {
 		return err
 	}
 	*reply = "ok"

--- a/logwolf-server/toolbox/data/log.go
+++ b/logwolf-server/toolbox/data/log.go
@@ -1,19 +1,21 @@
 package data
 
 type JSONLogPayload struct {
-	Name     string   `json:"name"`
-	Data     string   `json:"data"`
-	Severity string   `json:"severity"`
-	Tags     []string `json:"tags"`
-	Duration int      `json:"duration"`
+	ProjectID string   `json:"project_id"`
+	Name      string   `json:"name"`
+	Data      string   `json:"data"`
+	Severity  string   `json:"severity"`
+	Tags      []string `json:"tags"`
+	Duration  int      `json:"duration"`
 }
 
 type RPCLogPayload struct {
-	Name     string
-	Data     string
-	Severity string
-	Tags     []string
-	Duration int
+	ProjectID string
+	Name      string
+	Data      string
+	Severity  string
+	Tags      []string
+	Duration  int
 }
 
 type RPCLogEntryFilter LogEntryFilter

--- a/logwolf-server/toolbox/data/log_test.go
+++ b/logwolf-server/toolbox/data/log_test.go
@@ -1,0 +1,56 @@
+package data
+
+import "testing"
+
+func TestLogEntryHasProjectID(t *testing.T) {
+	entry := LogEntry{
+		ProjectID: "proj-abc",
+		Name:      "test-event",
+		Severity:  "info",
+	}
+	if entry.ProjectID != "proj-abc" {
+		t.Errorf("LogEntry.ProjectID = %q, want %q", entry.ProjectID, "proj-abc")
+	}
+}
+
+func TestJSONLogPayloadHasProjectID(t *testing.T) {
+	p := JSONLogPayload{
+		ProjectID: "proj-xyz",
+		Name:      "test",
+		Severity:  "error",
+	}
+	if p.ProjectID != "proj-xyz" {
+		t.Errorf("JSONLogPayload.ProjectID = %q, want %q", p.ProjectID, "proj-xyz")
+	}
+}
+
+func TestRPCLogPayloadConversion(t *testing.T) {
+	json := JSONLogPayload{
+		ProjectID: "proj-123",
+		Name:      "conversion-test",
+		Data:      "{}",
+		Severity:  "warning",
+		Tags:      []string{"a", "b"},
+		Duration:  42,
+	}
+	rpc := RPCLogPayload(json)
+	if rpc.ProjectID != json.ProjectID {
+		t.Errorf("RPCLogPayload.ProjectID = %q, want %q", rpc.ProjectID, json.ProjectID)
+	}
+	if rpc.Name != json.Name {
+		t.Errorf("RPCLogPayload.Name = %q, want %q", rpc.Name, json.Name)
+	}
+	if rpc.Duration != json.Duration {
+		t.Errorf("RPCLogPayload.Duration = %d, want %d", rpc.Duration, json.Duration)
+	}
+}
+
+func TestSettingsRetentionArgs(t *testing.T) {
+	args := RetentionArgs{ProjectID: "proj-abc", Days: 30}
+	if args.ProjectID != "proj-abc" {
+		t.Errorf("RetentionArgs.ProjectID = %q, want %q", args.ProjectID, "proj-abc")
+	}
+	if args.Days != 30 {
+		t.Errorf("RetentionArgs.Days = %d, want %d", args.Days, 30)
+	}
+}

--- a/logwolf-server/toolbox/data/models.go
+++ b/logwolf-server/toolbox/data/models.go
@@ -23,6 +23,7 @@ type Models struct {
 
 type LogEntry struct {
 	ID        string    `bson:"_id,omitempty" json:"id,omitempty"`
+	ProjectID string    `bson:"project_id" json:"project_id"`
 	Name      string    `bson:"name" json:"name"`
 	Data      string    `bson:"data" json:"data"`
 	Severity  string    `bson:"severity" json:"severity"`
@@ -61,6 +62,7 @@ func New(mongo *mongo.Client) Models {
 func (m *Models) Insert(entry LogEntry) error {
 	collection := m.client.Database("logs").Collection("logs")
 	_, err := collection.InsertOne(context.TODO(), LogEntry{
+		ProjectID: entry.ProjectID,
 		Name:      entry.Name,
 		Data:      entry.Data,
 		Severity:  entry.Severity,

--- a/logwolf-server/toolbox/data/models.go
+++ b/logwolf-server/toolbox/data/models.go
@@ -131,6 +131,23 @@ func (m *Models) GetLog(id string) (*LogEntry, error) {
 	return &entry, nil
 }
 
+// EnsureLogsIndexes creates indexes on the logs collection required for
+// project-scoped queries and efficient pagination.
+func (m *Models) EnsureLogsIndexes() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	coll := m.client.Database("logs").Collection("logs")
+	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "project_id", Value: 1}, {Key: "created_at", Value: -1}},
+		Options: options.Index().SetName("project_id_created_at"),
+	})
+	if err != nil {
+		return fmt.Errorf("EnsureLogsIndexes: %w", err)
+	}
+	return nil
+}
+
 func (m *Models) DropLogsCollection() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/logwolf-server/toolbox/data/settings.go
+++ b/logwolf-server/toolbox/data/settings.go
@@ -23,20 +23,27 @@ type Settings struct {
 }
 
 type settingsDoc struct {
-	Key   string `bson:"key"`
-	Value int    `bson:"value"`
+	ProjectID string `bson:"project_id"`
+	Key       string `bson:"key"`
+	Value     int    `bson:"value"`
+}
+
+// RetentionArgs is the RPC argument for GetRetention and UpdateRetention.
+type RetentionArgs struct {
+	ProjectID string
+	Days      int
 }
 
 func (s *Settings) collection() *mongo.Collection {
 	return s.client.Database("logs").Collection("settings")
 }
 
-func (s *Settings) GetRetentionDays() (int, error) {
+func (s *Settings) GetRetentionDays(projectID string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	var doc settingsDoc
-	err := s.collection().FindOne(ctx, bson.M{"key": "retention_days"}).Decode(&doc)
+	err := s.collection().FindOne(ctx, bson.M{"project_id": projectID, "key": "retention_days"}).Decode(&doc)
 	if err == mongo.ErrNoDocuments {
 		return defaultRetentionDays, nil
 	}
@@ -46,7 +53,7 @@ func (s *Settings) GetRetentionDays() (int, error) {
 	return doc.Value, nil
 }
 
-func (s *Settings) SetRetentionDays(days int) error {
+func (s *Settings) SetRetentionDays(projectID string, days int) error {
 	if !ValidRetentionDays[days] {
 		return fmt.Errorf("SetRetentionDays: %d is not a valid retention value", days)
 	}
@@ -56,12 +63,27 @@ func (s *Settings) SetRetentionDays(days int) error {
 
 	_, err := s.collection().UpdateOne(
 		ctx,
-		bson.M{"key": "retention_days"},
-		bson.M{"$set": bson.M{"key": "retention_days", "value": days}},
+		bson.M{"project_id": projectID, "key": "retention_days"},
+		bson.M{"$set": bson.M{"project_id": projectID, "key": "retention_days", "value": days}},
 		options.Update().SetUpsert(true),
 	)
 	if err != nil {
 		return fmt.Errorf("SetRetentionDays: %w", err)
+	}
+	return nil
+}
+
+// EnsureSettingsIndex creates a compound unique index on (project_id, key).
+func (s *Settings) EnsureSettingsIndex() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_, err := s.collection().Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "project_id", Value: 1}, {Key: "key", Value: 1}},
+		Options: options.Index().SetUnique(true).SetName("unique_project_key"),
+	})
+	if err != nil {
+		return fmt.Errorf("EnsureSettingsIndex: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #5

## Summary
- Added mandatory `project_id` field to `LogEntry`, `JSONLogPayload`, and `RPCLogPayload`
- Updated `Settings.GetRetentionDays` / `SetRetentionDays` to accept a `projectID string` parameter
- Added `Settings.EnsureSettingsIndex()` creating a compound unique index on `settings.(project_id, key)`
- Added `RetentionArgs` struct to toolbox/data for the retention RPC calls
- Threaded `projectID` through logger RPC methods (`GetRetention`, `UpdateRetention`, `LogInfo`) and broker HTTP handlers
- Added unit tests for `project_id` on `LogEntry`, `JSONLogPayload`, `RPCLogPayload`, and `RetentionArgs`

## Test plan
- [ ] `cd logwolf-server/toolbox && go test ./...` — all 8 tests pass
- [ ] `cd logwolf-server/broker && go test ./...` — all 5 middleware tests pass
- [ ] `cd logwolf-server/broker && go build ./...` — compiles clean
- [ ] `cd logwolf-server/logger && go build ./...` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)