### PR TITLE
feat(toolbox): project-scope all query helpers, remove EnsureTTLIndex

### DIFF
--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -23,6 +23,8 @@ func (app *Config) CreateLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	payload.ProjectID = projectIDFromContext(r)
+
 	// Push to queue
 	evp := event.Payload{Action: "log", Log: data.JSONLogPayload(payload)}
 
@@ -64,6 +66,11 @@ func (app *Config) CreateLogBatch(w http.ResponseWriter, r *http.Request) {
 	if len(payloads) > 1000 {
 		app.errorJSON(w, fmt.Errorf("batch size %d exceeds maximum of 1000", len(payloads)), http.StatusRequestEntityTooLarge)
 		return
+	}
+
+	projectID := projectIDFromContext(r)
+	for i := range payloads {
+		payloads[i].ProjectID = projectID
 	}
 
 	// Pre-serialize all payloads before emitting any. This ensures a
@@ -125,7 +132,7 @@ func (app *Config) GetLogs(w http.ResponseWriter, r *http.Request) {
 
 	var result []data.LogEntry
 	err = client.Call("RPCServer.GetLogs", data.QueryParams{
-		// TODO - Filters
+		ProjectID:  projectIDFromContext(r),
 		Pagination: data.PaginationParams{Page: page, PageSize: pageSize},
 	}, &result)
 	if err != nil {
@@ -148,6 +155,8 @@ func (app *Config) DeleteLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	requestBody.ProjectID = projectIDFromContext(r)
+
 	client, err := rpc.Dial("tcp", "logger:5001")
 	if err != nil {
 		app.errorJSON(w, err)
@@ -155,7 +164,7 @@ func (app *Config) DeleteLog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var result int64
-	err = client.Call("RPCServer.DeleteLog", requestBody, &result)
+	err = client.Call("RPCServer.DeleteLog", data.RPCLogEntryFilter(requestBody), &result)
 	if err != nil {
 		app.errorJSON(w, err)
 		return
@@ -266,8 +275,9 @@ func (app *Config) GetMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	args := data.RetentionArgs{ProjectID: r.URL.Query().Get("project_id")}
 	var result data.Metrics
-	if err := client.Call("RPCServer.GetMetrics", "", &result); err != nil {
+	if err := client.Call("RPCServer.GetMetrics", &args, &result); err != nil {
 		app.errorJSON(w, err)
 		return
 	}

--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -275,7 +275,7 @@ func (app *Config) GetMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	args := data.RetentionArgs{ProjectID: r.URL.Query().Get("project_id")}
+	args := data.ProjectArgs{ProjectID: r.URL.Query().Get("project_id")}
 	var result data.Metrics
 	if err := client.Call("RPCServer.GetMetrics", &args, &result); err != nil {
 		app.errorJSON(w, err)

--- a/logwolf-server/broker/cmd/api/middleware.go
+++ b/logwolf-server/broker/cmd/api/middleware.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
@@ -14,8 +15,20 @@ import (
 	"time"
 )
 
+type contextKey string
+
+const projectIDKey contextKey = "projectID"
+
+func projectIDFromContext(r *http.Request) string {
+	if v, ok := r.Context().Value(projectIDKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
 type cacheEntry struct {
 	valid     bool
+	projectID string
 	expiresAt time.Time
 }
 
@@ -143,12 +156,13 @@ func (app *Config) requireAPIKeyWith(v keyValidator, next http.Handler) http.Han
 			}
 			log.Printf(`{"event":"auth","outcome":"allow","key_prefix":"%s","method":"%s","path":"%s","remote_addr":"%s","source":"cache"}`,
 				keyPrefix, r.Method, r.URL.Path, r.RemoteAddr)
-			next.ServeHTTP(w, r)
+			ctx := context.WithValue(r.Context(), projectIDKey, entry.projectID)
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 
 		// Cache miss — validate against DB via Logger RPC
-		valid, _, err := v.ValidateAPIKey(plaintext)
+		valid, key, err := v.ValidateAPIKey(plaintext)
 		if err != nil {
 			log.Printf(`{"event":"auth","outcome":"error","reason":"db_error","key_prefix":"%s","method":"%s","path":"%s","remote_addr":"%s","error":"%s"}`,
 				keyPrefix, r.Method, r.URL.Path, r.RemoteAddr, err.Error())
@@ -156,9 +170,14 @@ func (app *Config) requireAPIKeyWith(v keyValidator, next http.Handler) http.Han
 			return
 		}
 
+		projectID := ""
+		if key != nil {
+			projectID = key.ProjectID
+		}
+
 		// Write result to cache (keyed on hash).
 		keyCacheMu.Lock()
-		keyCache[cacheKey] = cacheEntry{valid: valid, expiresAt: time.Now().Add(cacheTTL)}
+		keyCache[cacheKey] = cacheEntry{valid: valid, projectID: projectID, expiresAt: time.Now().Add(cacheTTL)}
 		keyCacheMu.Unlock()
 
 		if !valid {
@@ -171,7 +190,8 @@ func (app *Config) requireAPIKeyWith(v keyValidator, next http.Handler) http.Han
 
 		log.Printf(`{"event":"auth","outcome":"allow","key_prefix":"%s","method":"%s","path":"%s","remote_addr":"%s","source":"db"}`,
 			keyPrefix, r.Method, r.URL.Path, r.RemoteAddr)
-		next.ServeHTTP(w, r)
+		ctx := context.WithValue(r.Context(), projectIDKey, projectID)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/logwolf-server/broker/cmd/api/middleware_test.go
+++ b/logwolf-server/broker/cmd/api/middleware_test.go
@@ -18,6 +18,12 @@ type alwaysInvalidKey struct{}
 
 func (a alwaysInvalidKey) ValidateAPIKey(string) (bool, *data.APIKey, error) { return false, nil, nil }
 
+type validKeyWithProject struct{ projectID string }
+
+func (v validKeyWithProject) ValidateAPIKey(string) (bool, *data.APIKey, error) {
+	return true, &data.APIKey{ProjectID: v.projectID}, nil
+}
+
 func okHandler(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
 
 func newApp() *Config { return &Config{} }
@@ -87,6 +93,37 @@ func TestRequireAPIKey_ExpiredCache(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 on expired cache, got %d", w.Code)
+	}
+}
+
+func TestRequireAPIKey_PropagatesProjectID(t *testing.T) {
+	const wantProjectID = "proj-abc123"
+	app := newApp()
+
+	var gotProjectID string
+	capture := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProjectID = projectIDFromContext(r)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := app.requireAPIKeyWith(validKeyWithProject{wantProjectID}, capture)
+
+	// First request: DB path
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, makeRequest("lw_projkey1234567"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if gotProjectID != wantProjectID {
+		t.Errorf("DB path: projectID in context = %q, want %q", gotProjectID, wantProjectID)
+	}
+
+	// Second request: cache path — projectID must still be propagated
+	gotProjectID = ""
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, makeRequest("lw_projkey1234567"))
+	if gotProjectID != wantProjectID {
+		t.Errorf("cache path: projectID in context = %q, want %q", gotProjectID, wantProjectID)
 	}
 }
 

--- a/logwolf-server/logger/cmd/api/main.go
+++ b/logwolf-server/logger/cmd/api/main.go
@@ -53,15 +53,6 @@ func main() {
 		log.Printf("Warning: could not ensure logs indexes: %v", err)
 	}
 
-	retentionDays, err := app.Models.Settings.GetRetentionDays("")
-	if err != nil {
-		log.Printf("Warning: could not read retention setting, using default: %v", err)
-		retentionDays = 90
-	}
-	if err := app.Models.Settings.EnsureTTLIndex(retentionDays); err != nil {
-		log.Printf("Warning: could not ensure TTL index: %v", err)
-	}
-
 	app.serve()
 }
 

--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -50,7 +50,7 @@ func (r *RPCServer) GetLogs(p data.QueryParams, resp *[]data.LogEntry) error {
 func (r *RPCServer) DeleteLog(f data.RPCLogEntryFilter, resp *int64) error {
 	log.Printf("Deleting log %+v...\n", f)
 
-	result, err := r.models.DeleteLog(f.ID)
+	result, err := r.models.DeleteLog(f.ID, f.ProjectID)
 	if err != nil {
 		log.Println("Error deleting document:", err)
 		return err
@@ -75,15 +75,12 @@ func (r *RPCServer) UpdateRetention(args *data.RetentionArgs, reply *string) err
 	if err := r.models.Settings.SetRetentionDays(args.ProjectID, args.Days); err != nil {
 		return err
 	}
-	if err := r.models.Settings.EnsureTTLIndex(args.Days); err != nil {
-		return err
-	}
 	*reply = "ok"
 	return nil
 }
 
-func (r *RPCServer) GetMetrics(args *string, reply *data.Metrics) error {
-	metrics, err := r.models.GetMetrics()
+func (r *RPCServer) GetMetrics(args *data.RetentionArgs, reply *data.Metrics) error {
+	metrics, err := r.models.GetMetrics(args.ProjectID)
 	if err != nil {
 		return err
 	}

--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -79,7 +79,7 @@ func (r *RPCServer) UpdateRetention(args *data.RetentionArgs, reply *string) err
 	return nil
 }
 
-func (r *RPCServer) GetMetrics(args *data.RetentionArgs, reply *data.Metrics) error {
+func (r *RPCServer) GetMetrics(args *data.ProjectArgs, reply *data.Metrics) error {
 	metrics, err := r.models.GetMetrics(args.ProjectID)
 	if err != nil {
 		return err

--- a/logwolf-server/toolbox/data/models.go
+++ b/logwolf-server/toolbox/data/models.go
@@ -113,7 +113,7 @@ func (m *Models) AllLogs(p QueryParams) ([]*LogEntry, error) {
 	return logs, nil
 }
 
-func (m *Models) GetLog(id string) (*LogEntry, error) {
+func (m *Models) GetLog(id, projectID string) (*LogEntry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -125,7 +125,7 @@ func (m *Models) GetLog(id string) (*LogEntry, error) {
 	}
 
 	var entry LogEntry
-	err = collection.FindOne(ctx, bson.M{"_id": docID}).Decode(&entry)
+	err = collection.FindOne(ctx, bson.M{"_id": docID, "project_id": projectID}).Decode(&entry)
 	if err != nil {
 		return nil, err
 	}

--- a/logwolf-server/toolbox/data/models.go
+++ b/logwolf-server/toolbox/data/models.go
@@ -34,11 +34,12 @@ type LogEntry struct {
 }
 
 type LogEntryFilter struct {
-	ID       string   `bson:"_id,omitempty" json:"id,omitempty"`
-	Name     string   `bson:"name,omitempty" json:"name,omitempty"`
-	Data     string   `bson:"data,omitempty" json:"data,omitempty"`
-	Severity string   `bson:"severity,omitempty" json:"severity,omitempty"`
-	Tags     []string `bson:"tags,omitempty" json:"tags,omitempty"`
+	ID        string   `bson:"_id,omitempty" json:"id,omitempty"`
+	ProjectID string   `bson:"project_id,omitempty" json:"project_id,omitempty"`
+	Name      string   `bson:"name,omitempty" json:"name,omitempty"`
+	Data      string   `bson:"data,omitempty" json:"data,omitempty"`
+	Severity  string   `bson:"severity,omitempty" json:"severity,omitempty"`
+	Tags      []string `bson:"tags,omitempty" json:"tags,omitempty"`
 }
 
 type PaginationParams struct {
@@ -47,6 +48,7 @@ type PaginationParams struct {
 }
 
 type QueryParams struct {
+	ProjectID  string
 	Pagination PaginationParams
 }
 
@@ -87,7 +89,7 @@ func (m *Models) AllLogs(p QueryParams) ([]*LogEntry, error) {
 	opts := options.Find()
 	opts.SetSort(bson.D{{Key: "created_at", Value: -1}}).SetLimit(p.Pagination.PageSize).SetSkip(p.Pagination.PageSize * (p.Pagination.Page - 1))
 
-	cursor, err := collection.Find(context.TODO(), bson.D{}, opts)
+	cursor, err := collection.Find(context.TODO(), bson.M{"project_id": p.ProjectID}, opts)
 	if err != nil {
 		log.Println("Error finding docs")
 		return nil, err
@@ -190,7 +192,7 @@ func (m *Models) UpdateLog() (*mongo.UpdateResult, error) {
 	return result, nil
 }
 
-func (m *Models) DeleteLog(id string) (*mongo.DeleteResult, error) {
+func (m *Models) DeleteLog(id, projectID string) (*mongo.DeleteResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -201,7 +203,7 @@ func (m *Models) DeleteLog(id string) (*mongo.DeleteResult, error) {
 		return nil, err
 	}
 
-	result, err := collection.DeleteOne(ctx, bson.M{"_id": docID})
+	result, err := collection.DeleteOne(ctx, bson.M{"_id": docID, "project_id": projectID})
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +226,7 @@ type Metrics struct {
 	TopTags       []TagCount `bson:"top_tags" json:"top_tags"`
 }
 
-func (m *Models) GetMetrics() (*Metrics, error) {
+func (m *Models) GetMetrics(projectID string) (*Metrics, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -232,6 +234,7 @@ func (m *Models) GetMetrics() (*Metrics, error) {
 	since24h := time.Now().Add(-24 * time.Hour)
 
 	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"project_id": projectID}}},
 		{{Key: "$facet", Value: bson.D{
 			{Key: "total_events", Value: bson.A{
 				bson.D{{Key: "$count", Value: "count"}},

--- a/logwolf-server/toolbox/data/models_test.go
+++ b/logwolf-server/toolbox/data/models_test.go
@@ -1,0 +1,68 @@
+package data
+
+import "testing"
+
+func TestQueryParamsHasProjectID(t *testing.T) {
+	p := QueryParams{
+		ProjectID:  "proj-alpha",
+		Pagination: PaginationParams{Page: 1, PageSize: 20},
+	}
+	if p.ProjectID != "proj-alpha" {
+		t.Errorf("QueryParams.ProjectID = %q, want %q", p.ProjectID, "proj-alpha")
+	}
+}
+
+func TestLogEntryFilterHasProjectID(t *testing.T) {
+	f := LogEntryFilter{
+		ID:        "abc123",
+		ProjectID: "proj-beta",
+	}
+	if f.ProjectID != "proj-beta" {
+		t.Errorf("LogEntryFilter.ProjectID = %q, want %q", f.ProjectID, "proj-beta")
+	}
+}
+
+// TestMultiProjectIsolation_Structs verifies that LogEntry, QueryParams, and
+// LogEntryFilter all carry ProjectID so that DB queries can be scoped to a
+// single project and entries from different projects can be distinguished.
+func TestMultiProjectIsolation_Structs(t *testing.T) {
+	projectA := "proj-aaa"
+	projectB := "proj-bbb"
+
+	entryA := LogEntry{ProjectID: projectA, Name: "event-a", Severity: "info"}
+	entryB := LogEntry{ProjectID: projectB, Name: "event-b", Severity: "error"}
+
+	if entryA.ProjectID == entryB.ProjectID {
+		t.Error("entries from different projects must have distinct ProjectIDs")
+	}
+
+	filterA := LogEntryFilter{ProjectID: projectA}
+	filterB := LogEntryFilter{ProjectID: projectB}
+
+	if filterA.ProjectID == filterB.ProjectID {
+		t.Error("filters for different projects must have distinct ProjectIDs")
+	}
+
+	queryA := QueryParams{ProjectID: projectA, Pagination: PaginationParams{Page: 1, PageSize: 10}}
+	queryB := QueryParams{ProjectID: projectB, Pagination: PaginationParams{Page: 1, PageSize: 10}}
+
+	if queryA.ProjectID == queryB.ProjectID {
+		t.Error("query params for different projects must have distinct ProjectIDs")
+	}
+
+	// RPCLogEntryFilter is an alias for LogEntryFilter, so ProjectID is preserved.
+	rpcFilter := RPCLogEntryFilter(filterA)
+	if rpcFilter.ProjectID != projectA {
+		t.Errorf("RPCLogEntryFilter.ProjectID = %q, want %q", rpcFilter.ProjectID, projectA)
+	}
+}
+
+func TestRPCLogEntryFilterHasProjectID(t *testing.T) {
+	f := RPCLogEntryFilter{
+		ID:        "xyz",
+		ProjectID: "proj-gamma",
+	}
+	if f.ProjectID != "proj-gamma" {
+		t.Errorf("RPCLogEntryFilter.ProjectID = %q, want %q", f.ProjectID, "proj-gamma")
+	}
+}

--- a/logwolf-server/toolbox/data/settings.go
+++ b/logwolf-server/toolbox/data/settings.go
@@ -27,6 +27,11 @@ type settingsDoc struct {
 	Value     int    `bson:"value"`
 }
 
+// ProjectArgs is the RPC argument for calls that need only a project scope.
+type ProjectArgs struct {
+	ProjectID string
+}
+
 // RetentionArgs is the RPC argument for GetRetention and UpdateRetention.
 type RetentionArgs struct {
 	ProjectID string

--- a/logwolf-server/toolbox/data/settings.go
+++ b/logwolf-server/toolbox/data/settings.go
@@ -3,7 +3,6 @@ package data
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -88,72 +87,3 @@ func (s *Settings) EnsureSettingsIndex() error {
 	return nil
 }
 
-// EnsureTTLIndex creates or updates the TTL index on the logs collection.
-// days=0 means retain forever — the index is dropped if it exists.
-func (s *Settings) EnsureTTLIndex(days int) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	coll := s.client.Database("logs").Collection("logs")
-	const indexName = "ttl_created_at"
-
-	// Check if the index already exists
-	cursor, err := coll.Indexes().List(ctx)
-	if err != nil {
-		return fmt.Errorf("EnsureTTLIndex list: %w", err)
-	}
-	defer cursor.Close(ctx)
-
-	indexExists := false
-	for cursor.Next(ctx) {
-		var idx bson.M
-		if err := cursor.Decode(&idx); err != nil {
-			continue
-		}
-		if idx["name"] == indexName {
-			indexExists = true
-			break
-		}
-	}
-
-	// days=0: retain forever — drop existing TTL index if present
-	if days == 0 {
-		if indexExists {
-			if _, err := coll.Indexes().DropOne(ctx, indexName); err != nil {
-				return fmt.Errorf("EnsureTTLIndex drop: %w", err)
-			}
-			log.Println("TTL index removed: logs will be retained forever")
-		}
-		return nil
-	}
-
-	expireAfterSeconds := int32(days * 24 * 60 * 60)
-
-	if indexExists {
-		// Update existing index via collMod
-		db := s.client.Database("logs")
-		cmd := bson.D{
-			{Key: "collMod", Value: "logs"},
-			{Key: "index", Value: bson.D{
-				{Key: "name", Value: indexName},
-				{Key: "expireAfterSeconds", Value: expireAfterSeconds},
-			}},
-		}
-		if err := db.RunCommand(ctx, cmd).Err(); err != nil {
-			return fmt.Errorf("EnsureTTLIndex collMod: %w", err)
-		}
-		log.Printf("TTL index updated: logs older than %d days will be purged", days)
-		return nil
-	}
-
-	// Create fresh index
-	indexModel := mongo.IndexModel{
-		Keys:    bson.D{{Key: "created_at", Value: 1}},
-		Options: options.Index().SetExpireAfterSeconds(expireAfterSeconds).SetName(indexName),
-	}
-	if _, err := coll.Indexes().CreateOne(ctx, indexModel); err != nil {
-		return fmt.Errorf("EnsureTTLIndex create: %w", err)
-	}
-	log.Printf("TTL index created: logs older than %d days will be purged", days)
-	return nil
-}


### PR DESCRIPTION
Closes #6

## Summary

- **`AllLogs`** now filters by `project_id` via a new `QueryParams.ProjectID` field
- **`DeleteLog`** scopes the delete to `(id, project_id)` — prevents cross-project deletions
- **`GetMetrics`** accepts `projectID string` and prepends a `$match` stage before the `$facet` pipeline
- **`LogEntryFilter`** gains `ProjectID` (propagated as `RPCLogEntryFilter` to the logger)
- **`EnsureTTLIndex`** removed from `Settings` (replaced by the background cleanup job per issue spec)
- Logger startup: global-retention bootstrap code removed
- Broker middleware: resolved `APIKey.ProjectID` is stored in request context after auth (both cache hit and DB paths)
- Broker handlers: `CreateLog`, `CreateLogBatch`, `GetLogs`, `DeleteLog`, `GetMetrics` all extract and propagate `projectID` from context or query params

## Test plan

- [x] `go build ./toolbox/... ./logger/... ./broker/... ./listener/...` — all compile clean
- [x] All existing unit tests pass (`go test ./toolbox/... ./broker/... -v`)
- [x] New `models_test.go` — multi-project fixture tests verifying `QueryParams`, `LogEntryFilter`, `RPCLogEntryFilter`, and `LogEntry` all carry `ProjectID` for isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)