### PR TITLE
feat(logger): per-project background retention cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ Per-service env vars:
 | `BROKER_PORT`         | broker           | `80`                          | HTTP listen port                         |
 | `LOGGER_RPC_PORT`     | logger           | `5001`                        | RPC listen port                          |
 | `LOGGER_HTTP_PORT`    | logger           | `80`                          | HTTP health check port                   |
+| `CLEANUP_INTERVAL`    | logger           | `1h`                          | Per-project retention cleanup frequency  |
 | `API_URL`             | frontend         | —                             | Broker base URL                          |
 | `INTERNAL_API_SECRET` | frontend         | —                             | Shared secret for internal Broker routes |
 | `SESSION_SECRET`      | frontend         | —                             | iron-session signing key                 |

--- a/logwolf-server/.env.example
+++ b/logwolf-server/.env.example
@@ -16,3 +16,7 @@ INTERNAL_API_SECRET=
 # API key used by the frontend to instrument itself
 # Generate one from the dashboard after first boot, then paste it here and restart
 API_KEY=
+
+# Logger: how often the per-project retention cleanup runs (Go duration string, e.g. 1h, 30m)
+# Default: 1h
+CLEANUP_INTERVAL=

--- a/logwolf-server/integration/retention_cleanup_test.go
+++ b/logwolf-server/integration/retention_cleanup_test.go
@@ -132,24 +132,15 @@ func TestRetentionCleanup(t *testing.T) {
 
 	waitForTCP(t, loggerRPCAddr, 30*time.Second)
 
-	// Wait long enough for cleanup to trigger (interval=2s, give it 10s headroom).
-	time.Sleep(5 * time.Second)
-
 	// --- Assertions ---
 
 	coll := db.Collection("logs")
 
-	// The expired log must be gone.
-	n, err := coll.CountDocuments(ctx, bson.M{"name": expiredLogName})
-	if err != nil {
-		t.Fatalf("count expired log: %v", err)
-	}
-	if n != 0 {
-		t.Errorf("expected expired log %q to be deleted, but it still exists", expiredLogName)
-	}
+	// The cleanup runs immediately at startup; poll until the expired log disappears.
+	waitForLogGone(t, coll, expiredLogName, 10*time.Second)
 
 	// The fresh log must remain.
-	n, err = coll.CountDocuments(ctx, bson.M{"name": freshLogName})
+	n, err := coll.CountDocuments(ctx, bson.M{"name": freshLogName})
 	if err != nil {
 		t.Fatalf("count fresh log: %v", err)
 	}
@@ -165,4 +156,18 @@ func TestRetentionCleanup(t *testing.T) {
 	if n != 1 {
 		t.Errorf("expected infinite-retention log %q to be present, but it was deleted", oldLogName)
 	}
+}
+
+// waitForLogGone polls until no document with the given name exists, or the timeout elapses.
+func waitForLogGone(t *testing.T, coll *mongo.Collection, name string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		n, err := coll.CountDocuments(context.Background(), bson.M{"name": name})
+		if err == nil && n == 0 {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	t.Errorf("log %q still present after %s", name, timeout)
 }

--- a/logwolf-server/integration/retention_cleanup_test.go
+++ b/logwolf-server/integration/retention_cleanup_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TestRetentionCleanup verifies that the logger's background cleanup goroutine
+// deletes expired log entries while leaving unexpired ones intact, and that
+// projects configured for infinite retention (days=0) are not touched.
+func TestRetentionCleanup(t *testing.T) {
+	ctx := context.Background()
+
+	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mongo:4.2.16-bionic",
+			ExposedPorts: []string{"27017/tcp"},
+			Env: map[string]string{
+				"MONGO_INITDB_ROOT_USERNAME": "admin",
+				"MONGO_INITDB_ROOT_PASSWORD": "password",
+			},
+			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("mongo container: %v", err)
+	}
+	defer mongoC.Terminate(ctx)
+
+	mongoHost, _ := mongoC.Host(ctx)
+	mongoPort, _ := mongoC.MappedPort(ctx, "27017")
+	mongoURI := fmt.Sprintf("mongodb://admin:password@%s:%s", mongoHost, mongoPort.Port())
+
+	// Connect directly to MongoDB for seeding and assertions.
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI).
+		SetAuth(options.Credential{Username: "admin", Password: "password"}))
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	t.Cleanup(func() { client.Disconnect(context.Background()) })
+
+	db := client.Database("logs")
+
+	// --- Seed test data ---
+
+	// Project A: 30-day retention, has an expired log and a fresh log.
+	projectA := primitive.NewObjectID()
+	projectAStr := projectA.Hex()
+
+	// Project B: infinite retention (days=0), has an old log that must NOT be deleted.
+	projectB := primitive.NewObjectID()
+	projectBStr := projectB.Hex()
+
+	// Insert projects into the projects collection.
+	_, err = db.Collection("projects").InsertMany(ctx, []interface{}{
+		bson.M{"_id": projectA, "name": "Project A", "slug": "project-a", "created_at": time.Now()},
+		bson.M{"_id": projectB, "name": "Project B", "slug": "project-b", "created_at": time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("insert projects: %v", err)
+	}
+
+	// Set retention settings.
+	_, err = db.Collection("settings").InsertMany(ctx, []interface{}{
+		bson.M{"project_id": projectAStr, "key": "retention_days", "value": 30},
+		bson.M{"project_id": projectBStr, "key": "retention_days", "value": 0},
+	})
+	if err != nil {
+		t.Fatalf("insert settings: %v", err)
+	}
+
+	// Project A: expired log (31 days old) and a fresh log (now).
+	expiredLogName := "expired-log-project-a"
+	freshLogName := "fresh-log-project-a"
+	oldLogName := "old-log-project-b-forever"
+
+	_, err = db.Collection("logs").InsertMany(ctx, []interface{}{
+		bson.M{
+			"project_id": projectAStr,
+			"name":       expiredLogName,
+			"data":       "{}",
+			"severity":   "info",
+			"tags":       bson.A{},
+			"created_at": time.Now().Add(-31 * 24 * time.Hour),
+			"updated_at": time.Now().Add(-31 * 24 * time.Hour),
+		},
+		bson.M{
+			"project_id": projectAStr,
+			"name":       freshLogName,
+			"data":       "{}",
+			"severity":   "info",
+			"tags":       bson.A{},
+			"created_at": time.Now(),
+			"updated_at": time.Now(),
+		},
+		bson.M{
+			"project_id": projectBStr,
+			"name":       oldLogName,
+			"data":       "{}",
+			"severity":   "info",
+			"tags":       bson.A{},
+			"created_at": time.Now().Add(-365 * 24 * time.Hour),
+			"updated_at": time.Now().Add(-365 * 24 * time.Hour),
+		},
+	})
+	if err != nil {
+		t.Fatalf("insert logs: %v", err)
+	}
+
+	// --- Start the logger with a fast cleanup interval ---
+	loggerRPCAddr := freeAddr(t)
+	loggerHTTPAddr := freeAddr(t)
+
+	startProcess(t, "../logger/cmd/api", map[string]string{
+		"MONGO_URL":        mongoURI,
+		"LOGGER_RPC_PORT":  portOf(loggerRPCAddr),
+		"LOGGER_HTTP_PORT": portOf(loggerHTTPAddr),
+		"CLEANUP_INTERVAL": "2s",
+	})
+
+	waitForTCP(t, loggerRPCAddr, 30*time.Second)
+
+	// Wait long enough for cleanup to trigger (interval=2s, give it 10s headroom).
+	time.Sleep(5 * time.Second)
+
+	// --- Assertions ---
+
+	coll := db.Collection("logs")
+
+	// The expired log must be gone.
+	n, err := coll.CountDocuments(ctx, bson.M{"name": expiredLogName})
+	if err != nil {
+		t.Fatalf("count expired log: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected expired log %q to be deleted, but it still exists", expiredLogName)
+	}
+
+	// The fresh log must remain.
+	n, err = coll.CountDocuments(ctx, bson.M{"name": freshLogName})
+	if err != nil {
+		t.Fatalf("count fresh log: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected fresh log %q to be present, but it was deleted", freshLogName)
+	}
+
+	// The infinite-retention log must remain.
+	n, err = coll.CountDocuments(ctx, bson.M{"name": oldLogName})
+	if err != nil {
+		t.Fatalf("count infinite-retention log: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected infinite-retention log %q to be present, but it was deleted", oldLogName)
+	}
+}

--- a/logwolf-server/logger/cmd/api/cleanup.go
+++ b/logwolf-server/logger/cmd/api/cleanup.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+)
+
+func cleanupInterval() time.Duration {
+	if s := os.Getenv("CLEANUP_INTERVAL"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			return d
+		}
+	}
+	return time.Hour
+}
+
+func (app *Config) runCleanup(ctx context.Context) {
+	interval := cleanupInterval()
+	log.Printf("Retention cleanup: starting, interval=%s", interval)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	app.cleanupExpiredLogs(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Retention cleanup: shutting down")
+			return
+		case <-ticker.C:
+			app.cleanupExpiredLogs(ctx)
+		}
+	}
+}
+
+func (app *Config) cleanupExpiredLogs(ctx context.Context) {
+	projects, err := app.Models.GetAllProjects(ctx)
+	if err != nil {
+		log.Printf("Retention cleanup: error fetching projects: %v", err)
+		return
+	}
+
+	for _, p := range projects {
+		projectID := p.ID.Hex()
+
+		days, err := app.Models.Settings.GetRetentionDays(projectID)
+		if err != nil {
+			log.Printf("Retention cleanup: project %s: error reading retention: %v", projectID, err)
+			continue
+		}
+
+		if days == 0 {
+			continue
+		}
+
+		threshold := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+		deleted, err := app.Models.DeleteExpiredLogs(ctx, projectID, threshold)
+		if err != nil {
+			log.Printf("Retention cleanup: project %s: error deleting: %v", projectID, err)
+			continue
+		}
+
+		if deleted > 0 {
+			log.Printf("Retention cleanup: project %s: deleted %d expired logs (retention=%dd)", projectID, deleted, days)
+		}
+	}
+}

--- a/logwolf-server/logger/cmd/api/cleanup.go
+++ b/logwolf-server/logger/cmd/api/cleanup.go
@@ -9,7 +9,10 @@ import (
 
 func cleanupInterval() time.Duration {
 	if s := os.Getenv("CLEANUP_INTERVAL"); s != "" {
-		if d, err := time.ParseDuration(s); err == nil {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			log.Printf("Warning: invalid CLEANUP_INTERVAL %q, using default 1h: %v", s, err)
+		} else {
 			return d
 		}
 	}

--- a/logwolf-server/logger/cmd/api/cleanup.go
+++ b/logwolf-server/logger/cmd/api/cleanup.go
@@ -40,7 +40,10 @@ func (app *Config) runCleanup(ctx context.Context) {
 }
 
 func (app *Config) cleanupExpiredLogs(ctx context.Context) {
-	projects, err := app.Models.GetAllProjects(ctx)
+	passCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	projects, err := app.Models.GetAllProjects(passCtx)
 	if err != nil {
 		log.Printf("Retention cleanup: error fetching projects: %v", err)
 		return
@@ -60,7 +63,7 @@ func (app *Config) cleanupExpiredLogs(ctx context.Context) {
 		}
 
 		threshold := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
-		deleted, err := app.Models.DeleteExpiredLogs(ctx, projectID, threshold)
+		deleted, err := app.Models.DeleteExpiredLogs(passCtx, projectID, threshold)
 		if err != nil {
 			log.Printf("Retention cleanup: project %s: error deleting: %v", projectID, err)
 			continue

--- a/logwolf-server/logger/cmd/api/main.go
+++ b/logwolf-server/logger/cmd/api/main.go
@@ -17,10 +17,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-const (
-	grpcPort = "50001"
-)
-
 var client *mongo.Client
 
 type Config struct {

--- a/logwolf-server/logger/cmd/api/main.go
+++ b/logwolf-server/logger/cmd/api/main.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/rpc"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"go.mongodb.org/mongo-driver/mongo"
@@ -33,11 +35,10 @@ func main() {
 
 	client = mongoClient
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
 	defer func() {
-		if err = client.Disconnect(ctx); err != nil {
+		disconnectCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err = client.Disconnect(disconnectCtx); err != nil {
 			panic(err)
 		}
 	}()
@@ -53,35 +54,42 @@ func main() {
 		log.Printf("Warning: could not ensure logs indexes: %v", err)
 	}
 
-	app.serve()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	go app.runCleanup(ctx)
+
+	app.serve(ctx)
 }
 
-func (app *Config) serve() {
+func (app *Config) serve(ctx context.Context) {
 	err := rpc.Register(&RPCServer{models: app.Models})
 	if err != nil {
 		log.Panic(err)
 	}
 	go app.rpcListen()
 
-	err = app.httpListen()
-	if err != nil {
-		log.Panic(err)
-	}
-}
-
-func (app *Config) httpListen() error {
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%s", httpPort()),
 		Handler: app.routes(),
 	}
 
-	log.Println("Starting HTTP server on port", httpPort())
-	err := srv.ListenAndServe()
-	if err != nil {
-		return (err)
-	}
+	go func() {
+		log.Println("Starting HTTP server on port", httpPort())
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("HTTP server error: %v", err)
+		}
+	}()
 
-	return nil
+	<-ctx.Done()
+	log.Println("Shutting down HTTP server...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("HTTP server shutdown error: %v", err)
+	}
 }
 
 func (app *Config) rpcListen() error {

--- a/logwolf-server/toolbox/data/models.go
+++ b/logwolf-server/toolbox/data/models.go
@@ -150,6 +150,17 @@ func (m *Models) EnsureLogsIndexes() error {
 	return nil
 }
 
+func (m *Models) DeleteExpiredLogs(ctx context.Context, projectID string, before time.Time) (int64, error) {
+	result, err := m.client.Database("logs").Collection("logs").DeleteMany(ctx, bson.M{
+		"project_id": projectID,
+		"created_at": bson.M{"$lt": before},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("DeleteExpiredLogs: %w", err)
+	}
+	return result.DeletedCount, nil
+}
+
 func (m *Models) DropLogsCollection() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/logwolf-server/toolbox/data/project.go
+++ b/logwolf-server/toolbox/data/project.go
@@ -241,6 +241,20 @@ func (m *Models) IsMember(projectID primitive.ObjectID, githubLogin string) (boo
 	return n > 0, nil
 }
 
+func (m *Models) GetAllProjects(ctx context.Context) ([]Project, error) {
+	cursor, err := m.client.Database("logs").Collection("projects").Find(ctx, bson.M{})
+	if err != nil {
+		return nil, fmt.Errorf("GetAllProjects: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var projects []Project
+	if err := cursor.All(ctx, &projects); err != nil {
+		return nil, fmt.Errorf("GetAllProjects decode: %w", err)
+	}
+	return projects, nil
+}
+
 func (m *Models) GetProjectsForUser(githubLogin string) ([]Project, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

- Replaces the global MongoDB TTL index strategy with a per-project background cleanup goroutine running in the logger service
- Adds `CLEANUP_INTERVAL` env var (default `1h`) to configure the cleanup frequency
- Projects with `retention_days = 0` are skipped (infinite retention)
- Wires SIGTERM/SIGINT graceful shutdown through a shared context, cleanly terminating both the cleanup goroutine and the HTTP server
- Adds `GetAllProjects` and `DeleteExpiredLogs` to the toolbox `data` package
- Adds integration test (`TestRetentionCleanup`) covering: expired log deletion, fresh log preservation, and infinite-retention skip

Closes #9

## Test plan

- [ ] `cd logwolf-server/toolbox && go build ./...` passes
- [ ] `cd logwolf-server/logger && go build ./...` passes
- [ ] `cd logwolf-server/integration && go test -tags integration -run TestRetentionCleanup -v -timeout 5m` passes
- [ ] Full integration suite: `cd logwolf-server/integration && go test -tags integration ./... -v -timeout 5m` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)