### PR TITLE
feat(logger): add project management RPC methods

### DIFF
--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -120,6 +120,9 @@ func (r *RPCServer) GetProject(args *data.RPCProjectIDArgs, reply *data.Project)
 }
 
 func (r *RPCServer) UpdateProject(args *data.RPCUpdateProjectArgs, reply *data.Project) error {
+	if !data.ValidSlug(args.Slug) {
+		return fmt.Errorf("UpdateProject: invalid slug %q", args.Slug)
+	}
 	log.Printf("Updating project: %s", args.ID)
 	id, err := primitive.ObjectIDFromHex(args.ID)
 	if err != nil {
@@ -181,7 +184,7 @@ func (r *RPCServer) AddMember(args *data.RPCAddMemberArgs, reply *string) error 
 	return nil
 }
 
-func (r *RPCServer) RemoveMember(args *data.RPCMemberArgs, reply *string) error {
+func (r *RPCServer) RemoveMember(args *data.RPCRemoveMemberArgs, reply *string) error {
 	log.Printf("Removing member %s from project %s", args.GithubLogin, args.ProjectID)
 	projectID, err := primitive.ObjectIDFromHex(args.ProjectID)
 	if err != nil {

--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -91,6 +91,9 @@ func (r *RPCServer) GetMetrics(args *data.ProjectArgs, reply *data.Metrics) erro
 }
 
 func (r *RPCServer) CreateProject(args *data.RPCCreateProjectArgs, reply *data.Project) error {
+	if args.Name == "" {
+		return fmt.Errorf("CreateProject: name is required")
+	}
 	if !data.ValidSlug(args.Slug) {
 		return fmt.Errorf("CreateProject: invalid slug %q", args.Slug)
 	}
@@ -120,6 +123,9 @@ func (r *RPCServer) GetProject(args *data.RPCProjectIDArgs, reply *data.Project)
 }
 
 func (r *RPCServer) UpdateProject(args *data.RPCUpdateProjectArgs, reply *data.Project) error {
+	if args.Name == "" {
+		return fmt.Errorf("UpdateProject: name is required")
+	}
 	if !data.ValidSlug(args.Slug) {
 		return fmt.Errorf("UpdateProject: invalid slug %q", args.Slug)
 	}

--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -91,6 +91,9 @@ func (r *RPCServer) GetMetrics(args *data.ProjectArgs, reply *data.Metrics) erro
 }
 
 func (r *RPCServer) CreateProject(args *data.RPCCreateProjectArgs, reply *data.Project) error {
+	if !data.ValidSlug(args.Slug) {
+		return fmt.Errorf("CreateProject: invalid slug %q", args.Slug)
+	}
 	log.Printf("Creating project: %s (%s)", args.Name, args.Slug)
 	project, err := r.models.InsertProject(data.Project{Name: args.Name, Slug: args.Slug})
 	if err != nil {
@@ -157,6 +160,9 @@ func (r *RPCServer) ListUserProjects(args *data.RPCUserProjectsArgs, reply *[]da
 }
 
 func (r *RPCServer) AddMember(args *data.RPCAddMemberArgs, reply *string) error {
+	if !data.ValidRole(args.Role) {
+		return fmt.Errorf("AddMember: invalid role %q", args.Role)
+	}
 	log.Printf("Adding member %s to project %s", args.GithubLogin, args.ProjectID)
 	projectID, err := primitive.ObjectIDFromHex(args.ProjectID)
 	if err != nil {

--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"logwolf-toolbox/data"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type RPCServer struct {
@@ -85,5 +87,119 @@ func (r *RPCServer) GetMetrics(args *data.ProjectArgs, reply *data.Metrics) erro
 		return err
 	}
 	*reply = *metrics
+	return nil
+}
+
+func (r *RPCServer) CreateProject(args *data.RPCCreateProjectArgs, reply *data.Project) error {
+	log.Printf("Creating project: %s (%s)", args.Name, args.Slug)
+	project, err := r.models.InsertProject(data.Project{Name: args.Name, Slug: args.Slug})
+	if err != nil {
+		log.Println("Error creating project:", err)
+		return err
+	}
+	*reply = *project
+	return nil
+}
+
+func (r *RPCServer) GetProject(args *data.RPCProjectIDArgs, reply *data.Project) error {
+	log.Printf("Getting project: %s", args.ID)
+	id, err := primitive.ObjectIDFromHex(args.ID)
+	if err != nil {
+		return fmt.Errorf("GetProject: invalid ID: %w", err)
+	}
+	project, err := r.models.GetProject(id)
+	if err != nil {
+		log.Println("Error getting project:", err)
+		return err
+	}
+	*reply = *project
+	return nil
+}
+
+func (r *RPCServer) UpdateProject(args *data.RPCUpdateProjectArgs, reply *data.Project) error {
+	log.Printf("Updating project: %s", args.ID)
+	id, err := primitive.ObjectIDFromHex(args.ID)
+	if err != nil {
+		return fmt.Errorf("UpdateProject: invalid ID: %w", err)
+	}
+	project, err := r.models.UpdateProject(id, args.Name, args.Slug)
+	if err != nil {
+		log.Println("Error updating project:", err)
+		return err
+	}
+	*reply = *project
+	return nil
+}
+
+func (r *RPCServer) DeleteProject(args *data.RPCProjectIDArgs, reply *string) error {
+	log.Printf("Deleting project: %s", args.ID)
+	id, err := primitive.ObjectIDFromHex(args.ID)
+	if err != nil {
+		return fmt.Errorf("DeleteProject: invalid ID: %w", err)
+	}
+	if err := r.models.DeleteProject(id); err != nil {
+		log.Println("Error deleting project:", err)
+		return err
+	}
+	*reply = "ok"
+	return nil
+}
+
+func (r *RPCServer) ListUserProjects(args *data.RPCUserProjectsArgs, reply *[]data.Project) error {
+	log.Printf("Listing projects for user: %s", args.GithubLogin)
+	projects, err := r.models.GetProjectsForUser(args.GithubLogin)
+	if err != nil {
+		log.Println("Error listing user projects:", err)
+		return err
+	}
+	*reply = projects
+	return nil
+}
+
+func (r *RPCServer) AddMember(args *data.RPCAddMemberArgs, reply *string) error {
+	log.Printf("Adding member %s to project %s", args.GithubLogin, args.ProjectID)
+	projectID, err := primitive.ObjectIDFromHex(args.ProjectID)
+	if err != nil {
+		return fmt.Errorf("AddMember: invalid project ID: %w", err)
+	}
+	_, err = r.models.InsertProjectMember(data.ProjectMember{
+		ProjectID:   projectID,
+		GithubLogin: args.GithubLogin,
+		Role:        args.Role,
+	})
+	if err != nil {
+		log.Println("Error adding member:", err)
+		return err
+	}
+	*reply = "ok"
+	return nil
+}
+
+func (r *RPCServer) RemoveMember(args *data.RPCMemberArgs, reply *string) error {
+	log.Printf("Removing member %s from project %s", args.GithubLogin, args.ProjectID)
+	projectID, err := primitive.ObjectIDFromHex(args.ProjectID)
+	if err != nil {
+		return fmt.Errorf("RemoveMember: invalid project ID: %w", err)
+	}
+	if err := r.models.RemoveProjectMember(projectID, args.GithubLogin); err != nil {
+		log.Println("Error removing member:", err)
+		return err
+	}
+	*reply = "ok"
+	return nil
+}
+
+func (r *RPCServer) ListMembers(args *data.ProjectArgs, reply *[]data.ProjectMember) error {
+	log.Printf("Listing members for project: %s", args.ProjectID)
+	projectID, err := primitive.ObjectIDFromHex(args.ProjectID)
+	if err != nil {
+		return fmt.Errorf("ListMembers: invalid project ID: %w", err)
+	}
+	members, err := r.models.GetProjectMembers(projectID)
+	if err != nil {
+		log.Println("Error listing members:", err)
+		return err
+	}
+	*reply = members
 	return nil
 }

--- a/logwolf-server/toolbox/data/project.go
+++ b/logwolf-server/toolbox/data/project.go
@@ -255,6 +255,42 @@ func (m *Models) GetAllProjects(ctx context.Context) ([]Project, error) {
 	return projects, nil
 }
 
+// RPCCreateProjectArgs is the RPC argument for CreateProject.
+type RPCCreateProjectArgs struct {
+	Name string
+	Slug string
+}
+
+// RPCProjectIDArgs is the RPC argument for calls that take only a project ID.
+type RPCProjectIDArgs struct {
+	ID string
+}
+
+// RPCUpdateProjectArgs is the RPC argument for UpdateProject.
+type RPCUpdateProjectArgs struct {
+	ID   string
+	Name string
+	Slug string
+}
+
+// RPCUserProjectsArgs is the RPC argument for ListUserProjects.
+type RPCUserProjectsArgs struct {
+	GithubLogin string
+}
+
+// RPCAddMemberArgs is the RPC argument for AddMember.
+type RPCAddMemberArgs struct {
+	ProjectID   string
+	GithubLogin string
+	Role        string
+}
+
+// RPCMemberArgs is the RPC argument for RemoveMember.
+type RPCMemberArgs struct {
+	ProjectID   string
+	GithubLogin string
+}
+
 func (m *Models) GetProjectsForUser(githubLogin string) ([]Project, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/logwolf-server/toolbox/data/project.go
+++ b/logwolf-server/toolbox/data/project.go
@@ -38,6 +38,44 @@ type ProjectMember struct {
 	CreatedAt   time.Time          `bson:"created_at" json:"created_at"`
 }
 
+// RPC argument types for project and member operations.
+
+// RPCCreateProjectArgs is the RPC argument for CreateProject.
+type RPCCreateProjectArgs struct {
+	Name string
+	Slug string
+}
+
+// RPCProjectIDArgs is the RPC argument for calls that take only a project ID.
+type RPCProjectIDArgs struct {
+	ID string
+}
+
+// RPCUpdateProjectArgs is the RPC argument for UpdateProject.
+type RPCUpdateProjectArgs struct {
+	ID   string
+	Name string
+	Slug string
+}
+
+// RPCUserProjectsArgs is the RPC argument for ListUserProjects.
+type RPCUserProjectsArgs struct {
+	GithubLogin string
+}
+
+// RPCAddMemberArgs is the RPC argument for AddMember.
+type RPCAddMemberArgs struct {
+	ProjectID   string
+	GithubLogin string
+	Role        string
+}
+
+// RPCRemoveMemberArgs is the RPC argument for RemoveMember.
+type RPCRemoveMemberArgs struct {
+	ProjectID   string
+	GithubLogin string
+}
+
 // ValidSlug reports whether s is a valid URL-safe slug.
 func ValidSlug(s string) bool {
 	return slugRe.MatchString(s)
@@ -253,42 +291,6 @@ func (m *Models) GetAllProjects(ctx context.Context) ([]Project, error) {
 		return nil, fmt.Errorf("GetAllProjects decode: %w", err)
 	}
 	return projects, nil
-}
-
-// RPCCreateProjectArgs is the RPC argument for CreateProject.
-type RPCCreateProjectArgs struct {
-	Name string
-	Slug string
-}
-
-// RPCProjectIDArgs is the RPC argument for calls that take only a project ID.
-type RPCProjectIDArgs struct {
-	ID string
-}
-
-// RPCUpdateProjectArgs is the RPC argument for UpdateProject.
-type RPCUpdateProjectArgs struct {
-	ID   string
-	Name string
-	Slug string
-}
-
-// RPCUserProjectsArgs is the RPC argument for ListUserProjects.
-type RPCUserProjectsArgs struct {
-	GithubLogin string
-}
-
-// RPCAddMemberArgs is the RPC argument for AddMember.
-type RPCAddMemberArgs struct {
-	ProjectID   string
-	GithubLogin string
-	Role        string
-}
-
-// RPCMemberArgs is the RPC argument for RemoveMember.
-type RPCMemberArgs struct {
-	ProjectID   string
-	GithubLogin string
 }
 
 func (m *Models) GetProjectsForUser(githubLogin string) ([]Project, error) {


### PR DESCRIPTION
## Summary

- Adds 6 new RPC argument types to `toolbox/data/project.go` (`RPCCreateProjectArgs`, `RPCProjectIDArgs`, `RPCUpdateProjectArgs`, `RPCUserProjectsArgs`, `RPCAddMemberArgs`, `RPCMemberArgs`) so the broker can share them
- Implements 8 new `RPCServer` methods in `logger/cmd/api/rpc.go`: `CreateProject`, `GetProject`, `UpdateProject`, `DeleteProject`, `ListUserProjects`, `AddMember`, `RemoveMember`, `ListMembers` — each delegates to the corresponding toolbox data helper

Closes #10

## Test plan

- [x] `go build ./...` passes for toolbox, logger, and broker
- [ ] Logger service starts without errors (`go run ./cmd/api`)
- [ ] RPC methods callable from broker client after broker routes are wired up (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)