### PR TITLE
test(integration): assert project_id is stored on write path

### DIFF
--- a/logwolf-server/integration/helpers_test.go
+++ b/logwolf-server/integration/helpers_test.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const testProjectID = "integration"
+
 // startStack launches Logger, Listener, and Broker as subprocesses pointed at
 // the test containers. It registers t.Cleanup to kill them on test exit.
 // Returns the Broker's base URL (e.g. "http://127.0.0.1:18080").
@@ -85,7 +87,7 @@ func testAPIKey(t *testing.T, mongoURI string) string {
 	}
 
 	_, err = client.Database("logs").Collection("api_keys").InsertOne(ctx, bson.M{
-		"project_id": "integration",
+		"project_id": testProjectID,
 		"prefix":     plaintext[:10],
 		"hash":       string(hash),
 		"active":     true,

--- a/logwolf-server/integration/write_path_test.go
+++ b/logwolf-server/integration/write_path_test.go
@@ -116,14 +116,13 @@ func TestWritePathRoundTrip(t *testing.T) {
 	}
 
 	var doc struct {
-		Name      string `bson:"name"`
 		ProjectID string `bson:"project_id"`
 	}
 	err = collection.FindOne(ctx, bson.M{"name": "integration-test-event"}).Decode(&doc)
 	if err != nil {
 		t.Fatalf("log entry never appeared in MongoDB: %v", err)
 	}
-	if doc.ProjectID != "integration" {
-		t.Errorf("project_id = %q, want %q", doc.ProjectID, "integration")
+	if doc.ProjectID != testProjectID {
+		t.Errorf("project_id = %q, want %q", doc.ProjectID, testProjectID)
 	}
 }

--- a/logwolf-server/integration/write_path_test.go
+++ b/logwolf-server/integration/write_path_test.go
@@ -110,10 +110,20 @@ func TestWritePathRoundTrip(t *testing.T) {
 		count, err := collection.CountDocuments(ctx, bson.M{"name": "integration-test-event"})
 		t.Logf("attempt %d: count=%d err=%v", attempt, count, err)
 		if err == nil && count > 0 {
-			return // success
+			break
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	t.Fatal("log entry never appeared in MongoDB")
+	var doc struct {
+		Name      string `bson:"name"`
+		ProjectID string `bson:"project_id"`
+	}
+	err = collection.FindOne(ctx, bson.M{"name": "integration-test-event"}).Decode(&doc)
+	if err != nil {
+		t.Fatalf("log entry never appeared in MongoDB: %v", err)
+	}
+	if doc.ProjectID != "integration" {
+		t.Errorf("project_id = %q, want %q", doc.ProjectID, "integration")
+	}
 }


### PR DESCRIPTION
## Summary

- All pipeline changes for threading `project_id` were already in place on `feat/multi-tenancy` (middleware stores `key.ProjectID` in context, handlers pass it to RabbitMQ and RPC calls, listener forwards it via `RPCLogPayload`)
- `TestWritePathRoundTrip` polled MongoDB but returned on the first document hit without checking the `project_id` field — leaving acceptance criterion #1 uncovered
- This PR breaks out of the poll loop and then asserts `project_id == "integration"` (the project seeded by `testAPIKey`) before the test exits

Closes #11

## Test plan
- [ ] `go test -tags integration ./... -v -timeout 5m` in `logwolf-server/integration` passes
- [ ] `TestWritePathRoundTrip` fails if `project_id` is not stored (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)