### PR TITLE
feat(broker): add project management routes

### DIFF
--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -711,10 +711,6 @@ func (app *Config) ListProjectMembers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if members == nil {
-		members = []data.ProjectMember{}
-	}
-
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: members})
 }
 

--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -549,6 +549,9 @@ func (app *Config) CreateProject(w http.ResponseWriter, r *http.Request) {
 		GithubLogin: userLogin,
 		Role:        data.RoleOwner,
 	}, &reply); err != nil {
+		// Best-effort rollback: project must not exist without an owner.
+		var rollbackReply string
+		client.Call("RPCServer.DeleteProject", &data.RPCProjectIDArgs{ID: project.ID.Hex()}, &rollbackReply) //nolint:errcheck
 		app.errorJSON(w, err)
 		return
 	}
@@ -683,23 +686,20 @@ func (app *Config) ListProjectMembers(w http.ResponseWriter, r *http.Request) {
 	}
 	defer client.Close()
 
-	// Fetch members and check access in one RPC call.
-	args := data.ProjectArgs{ProjectID: id}
-	var members []data.ProjectMember
-	if err := client.Call("RPCServer.ListMembers", &args, &members); err != nil {
-		app.errorJSON(w, fmt.Errorf("project not found"), http.StatusNotFound)
+	role, err := getProjectRole(client, id, userLogin)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	if role == "" {
+		app.denyProjectAccess(w, client, id)
 		return
 	}
 
-	isMember := false
-	for _, m := range members {
-		if m.GithubLogin == userLogin {
-			isMember = true
-			break
-		}
-	}
-	if !isMember {
-		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+	args := data.ProjectArgs{ProjectID: id}
+	var members []data.ProjectMember
+	if err := client.Call("RPCServer.ListMembers", &args, &members); err != nil {
+		app.errorJSON(w, err)
 		return
 	}
 

--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -478,11 +478,16 @@ func checkLogger() serviceStatus {
 // but the user has no access. Used when getProjectRole returns an empty role.
 func (app *Config) denyProjectAccess(w http.ResponseWriter, client *rpc.Client, id string) {
 	var proj data.Project
-	if err := client.Call("RPCServer.GetProject", &data.RPCProjectIDArgs{ID: id}, &proj); err != nil {
-		app.errorJSON(w, fmt.Errorf("project not found"), http.StatusNotFound)
-	} else {
+	err := client.Call("RPCServer.GetProject", &data.RPCProjectIDArgs{ID: id}, &proj)
+	if err == nil {
 		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+		return
 	}
+	if strings.Contains(err.Error(), "no documents in result") {
+		app.errorJSON(w, fmt.Errorf("project not found"), http.StatusNotFound)
+		return
+	}
+	app.errorJSON(w, err)
 }
 
 func (app *Config) ListProjects(w http.ResponseWriter, r *http.Request) {
@@ -551,7 +556,7 @@ func (app *Config) CreateProject(w http.ResponseWriter, r *http.Request) {
 	}, &reply); err != nil {
 		// Best-effort rollback: project must not exist without an owner.
 		var rollbackReply string
-		client.Call("RPCServer.DeleteProject", &data.RPCProjectIDArgs{ID: project.ID.Hex()}, &rollbackReply) //nolint:errcheck
+		_ = client.Call("RPCServer.DeleteProject", &data.RPCProjectIDArgs{ID: project.ID.Hex()}, &rollbackReply)
 		app.errorJSON(w, err)
 		return
 	}
@@ -686,20 +691,23 @@ func (app *Config) ListProjectMembers(w http.ResponseWriter, r *http.Request) {
 	}
 	defer client.Close()
 
-	role, err := getProjectRole(client, id, userLogin)
-	if err != nil {
-		app.errorJSON(w, err)
-		return
-	}
-	if role == "" {
-		app.denyProjectAccess(w, client, id)
-		return
-	}
-
+	// Single ListMembers call: reuse the result for both the access check and the response.
 	args := data.ProjectArgs{ProjectID: id}
 	var members []data.ProjectMember
 	if err := client.Call("RPCServer.ListMembers", &args, &members); err != nil {
 		app.errorJSON(w, err)
+		return
+	}
+
+	isMember := false
+	for _, m := range members {
+		if m.GithubLogin == userLogin {
+			isMember = true
+			break
+		}
+	}
+	if !isMember {
+		app.denyProjectAccess(w, client, id)
 		return
 	}
 
@@ -797,6 +805,8 @@ func (app *Config) RemoveProjectMember(w http.ResponseWriter, r *http.Request) {
 		ProjectID:   id,
 		GithubLogin: login,
 	}, &reply); err != nil {
+		// net/rpc transmits errors as strings, so errors.Is won't work across the
+		// wire — string matching is the only way to detect data.ErrLastOwner here.
 		if strings.Contains(err.Error(), "last owner") {
 			app.errorJSON(w, fmt.Errorf("cannot remove the last owner"), http.StatusBadRequest)
 			return

--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/rpc"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -469,4 +470,340 @@ func checkLogger() serviceStatus {
 	conn.Close()
 
 	return serviceStatus{Status: "up"}
+}
+
+// --- Project management ---
+
+// denyProjectAccess sends a 404 if the project doesn't exist, or 403 if it exists
+// but the user has no access. Used when getProjectRole returns an empty role.
+func (app *Config) denyProjectAccess(w http.ResponseWriter, client *rpc.Client, id string) {
+	var proj data.Project
+	if err := client.Call("RPCServer.GetProject", &data.RPCProjectIDArgs{ID: id}, &proj); err != nil {
+		app.errorJSON(w, fmt.Errorf("project not found"), http.StatusNotFound)
+	} else {
+		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+	}
+}
+
+func (app *Config) ListProjects(w http.ResponseWriter, r *http.Request) {
+	userLogin := userLoginFromContext(r)
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	args := data.RPCUserProjectsArgs{GithubLogin: userLogin}
+	var projects []data.Project
+	if err := client.Call("RPCServer.ListUserProjects", &args, &projects); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	if projects == nil {
+		projects = []data.Project{}
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: projects})
+}
+
+func (app *Config) CreateProject(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	}
+	if err := app.readJSON(w, r, &body); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	if body.Name == "" {
+		app.errorJSON(w, fmt.Errorf("name is required"), http.StatusBadRequest)
+		return
+	}
+	if !data.ValidSlug(body.Slug) {
+		app.errorJSON(w, fmt.Errorf("invalid slug"), http.StatusBadRequest)
+		return
+	}
+
+	userLogin := userLoginFromContext(r)
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	var project data.Project
+	if err := client.Call("RPCServer.CreateProject", &data.RPCCreateProjectArgs{Name: body.Name, Slug: body.Slug}, &project); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	var reply string
+	if err := client.Call("RPCServer.AddMember", &data.RPCAddMemberArgs{
+		ProjectID:   project.ID.Hex(),
+		GithubLogin: userLogin,
+		Role:        data.RoleOwner,
+	}, &reply); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusCreated, jsonResponse{Error: false, Message: "Project created.", Data: project})
+}
+
+func (app *Config) GetProject(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userLogin := userLoginFromContext(r)
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	role, err := getProjectRole(client, id, userLogin)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	if role == "" {
+		app.denyProjectAccess(w, client, id)
+		return
+	}
+
+	var project data.Project
+	if err := client.Call("RPCServer.GetProject", &data.RPCProjectIDArgs{ID: id}, &project); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: project})
+}
+
+func (app *Config) UpdateProject(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userLogin := userLoginFromContext(r)
+
+	var body struct {
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	}
+	if err := app.readJSON(w, r, &body); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	if body.Name == "" {
+		app.errorJSON(w, fmt.Errorf("name is required"), http.StatusBadRequest)
+		return
+	}
+	if !data.ValidSlug(body.Slug) {
+		app.errorJSON(w, fmt.Errorf("invalid slug"), http.StatusBadRequest)
+		return
+	}
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	role, err := getProjectRole(client, id, userLogin)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	if role == "" {
+		app.denyProjectAccess(w, client, id)
+		return
+	}
+	if role != data.RoleOwner {
+		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+		return
+	}
+
+	var project data.Project
+	if err := client.Call("RPCServer.UpdateProject", &data.RPCUpdateProjectArgs{ID: id, Name: body.Name, Slug: body.Slug}, &project); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "Project updated.", Data: project})
+}
+
+func (app *Config) DeleteProject(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userLogin := userLoginFromContext(r)
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	role, err := getProjectRole(client, id, userLogin)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	if role == "" {
+		app.denyProjectAccess(w, client, id)
+		return
+	}
+	if role != data.RoleOwner {
+		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+		return
+	}
+
+	var reply string
+	if err := client.Call("RPCServer.DeleteProject", &data.RPCProjectIDArgs{ID: id}, &reply); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "Project deleted."})
+}
+
+func (app *Config) ListProjectMembers(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userLogin := userLoginFromContext(r)
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	// Fetch members and check access in one RPC call.
+	args := data.ProjectArgs{ProjectID: id}
+	var members []data.ProjectMember
+	if err := client.Call("RPCServer.ListMembers", &args, &members); err != nil {
+		app.errorJSON(w, fmt.Errorf("project not found"), http.StatusNotFound)
+		return
+	}
+
+	isMember := false
+	for _, m := range members {
+		if m.GithubLogin == userLogin {
+			isMember = true
+			break
+		}
+	}
+	if !isMember {
+		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+		return
+	}
+
+	if members == nil {
+		members = []data.ProjectMember{}
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: members})
+}
+
+func (app *Config) AddProjectMember(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userLogin := userLoginFromContext(r)
+
+	var body struct {
+		Login string `json:"login"`
+		Role  string `json:"role"`
+	}
+	if err := app.readJSON(w, r, &body); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	if body.Login == "" {
+		app.errorJSON(w, fmt.Errorf("login is required"), http.StatusBadRequest)
+		return
+	}
+	if !data.ValidRole(body.Role) {
+		app.errorJSON(w, fmt.Errorf("invalid role"), http.StatusBadRequest)
+		return
+	}
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	role, err := getProjectRole(client, id, userLogin)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	if role == "" {
+		app.denyProjectAccess(w, client, id)
+		return
+	}
+	if role != data.RoleOwner {
+		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+		return
+	}
+
+	var reply string
+	if err := client.Call("RPCServer.AddMember", &data.RPCAddMemberArgs{
+		ProjectID:   id,
+		GithubLogin: body.Login,
+		Role:        body.Role,
+	}, &reply); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusCreated, jsonResponse{Error: false, Message: "Member added."})
+}
+
+func (app *Config) RemoveProjectMember(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	login := chi.URLParam(r, "login")
+	userLogin := userLoginFromContext(r)
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	role, err := getProjectRole(client, id, userLogin)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	if role == "" {
+		app.denyProjectAccess(w, client, id)
+		return
+	}
+	if role != data.RoleOwner {
+		app.errorJSON(w, fmt.Errorf("forbidden"), http.StatusForbidden)
+		return
+	}
+
+	var reply string
+	if err := client.Call("RPCServer.RemoveMember", &data.RPCRemoveMemberArgs{
+		ProjectID:   id,
+		GithubLogin: login,
+	}, &reply); err != nil {
+		if strings.Contains(err.Error(), "last owner") {
+			app.errorJSON(w, fmt.Errorf("cannot remove the last owner"), http.StatusBadRequest)
+			return
+		}
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "Member removed."})
 }

--- a/logwolf-server/broker/cmd/api/middleware.go
+++ b/logwolf-server/broker/cmd/api/middleware.go
@@ -246,6 +246,22 @@ func checkProjectMembership(client *rpc.Client, projectID, userLogin string) (bo
 	return isMember, client.Call("RPCServer.CheckMembership", &args, &isMember)
 }
 
+// getProjectRole returns the role of userLogin in projectID ("owner", "member", or "").
+// An empty string means the user is not a member (project may or may not exist).
+func getProjectRole(client *rpc.Client, projectID, userLogin string) (string, error) {
+	args := data.ProjectArgs{ProjectID: projectID}
+	var members []data.ProjectMember
+	if err := client.Call("RPCServer.ListMembers", &args, &members); err != nil {
+		return "", err
+	}
+	for _, m := range members {
+		if m.GithubLogin == userLogin {
+			return m.Role, nil
+		}
+	}
+	return "", nil
+}
+
 func (app *Config) requireInternalSecret(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		secret := os.Getenv("INTERNAL_API_SECRET")

--- a/logwolf-server/broker/cmd/api/routes.go
+++ b/logwolf-server/broker/cmd/api/routes.go
@@ -34,6 +34,14 @@ func (app *Config) routes() http.Handler {
 		r.Get("/settings/retention", app.GetRetention)
 		r.Patch("/settings/retention", app.UpdateRetention)
 		r.Get("/metrics", app.GetMetrics)
+		r.Get("/projects", app.ListProjects)
+		r.Post("/projects", app.CreateProject)
+		r.Get("/projects/{id}", app.GetProject)
+		r.Patch("/projects/{id}", app.UpdateProject)
+		r.Delete("/projects/{id}", app.DeleteProject)
+		r.Get("/projects/{id}/members", app.ListProjectMembers)
+		r.Post("/projects/{id}/members", app.AddProjectMember)
+		r.Delete("/projects/{id}/members/{login}", app.RemoveProjectMember)
 	})
 
 	// Protected routes


### PR DESCRIPTION
Closes #13

## Summary
- Adds 8 internal routes (`GET/POST /projects`, `GET/PATCH/DELETE /projects/:id`, `GET/POST /projects/:id/members`, `DELETE /projects/:id/members/:login`) all protected by `requireInternalSecret` + `requireUserLogin`
- Adds `getProjectRole` helper in `middleware.go` that fetches the user's role via a single `ListMembers` RPC call, enabling both membership and ownership checks without extra round-trips
- Adds `denyProjectAccess` helper that distinguishes 404 (project not found) from 403 (forbidden) by probing `GetProject` when a user has no access
- `CreateProject` automatically adds the requesting user as owner via `AddMember`
- `RemoveProjectMember` detects the last-owner error from the RPC layer and returns 400

## Test plan
- [x] `go build ./cmd/api/...` — clean compile
- [x] `go test ./cmd/api/... -v` — all existing tests pass
- [ ] Integration tests against the full stack (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)