### PR TITLE
feat(frontend): currentProjectID in session + sidebar project switcher (#14)

### DIFF
--- a/logwolf-server/frontend/app/components/nav/app-sidebar.tsx
+++ b/logwolf-server/frontend/app/components/nav/app-sidebar.tsx
@@ -1,5 +1,7 @@
 import { KeyRound, LayoutDashboard, ScrollText, Settings } from 'lucide-react';
 
+import type { Project } from '~/lib/api';
+
 import type { Route } from '../../+types/root';
 import {
 	Sidebar,
@@ -13,6 +15,7 @@ import {
 	SidebarMenuButton,
 	SidebarMenuItem,
 } from '../ui/sidebar';
+import { ProjectSwitcher } from './project-switcher';
 
 const items = [
 	{
@@ -40,12 +43,17 @@ const items = [
 	},
 ] as const;
 
-type Props = Pick<Route.ComponentProps, 'matches'>;
-export function AppSidebar({ matches }: Props) {
+type Props = Pick<Route.ComponentProps, 'matches'> & {
+	projects: Project[];
+	currentProject: Project | undefined;
+	csrfToken: string;
+};
+export function AppSidebar({ matches, projects, currentProject, csrfToken }: Props) {
 	return (
 		<Sidebar>
-			{/* TODO - Logo */}
-			<SidebarHeader />
+			<SidebarHeader>
+				<ProjectSwitcher projects={projects} currentProject={currentProject} csrfToken={csrfToken} />
+			</SidebarHeader>
 
 			<SidebarContent>
 				<SidebarGroup>

--- a/logwolf-server/frontend/app/components/nav/project-switcher.tsx
+++ b/logwolf-server/frontend/app/components/nav/project-switcher.tsx
@@ -1,0 +1,96 @@
+import { Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { Link, useLocation, useSubmit } from 'react-router';
+
+import type { Project } from '~/lib/api';
+
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from '../ui/sidebar';
+
+type Props = {
+	projects: Project[];
+	currentProject: Project | undefined;
+	csrfToken: string;
+};
+export function ProjectSwitcher({ projects, currentProject, csrfToken }: Props) {
+	const { isMobile } = useSidebar();
+	const submit = useSubmit();
+	const location = useLocation();
+
+	function switchTo(projectId: string) {
+		if (projectId === currentProject?.id) return;
+
+		// The action swaps the session's project and sends us back here, which
+		// revalidates every loader on the page against the new project.
+		submit(
+			{ projectId, redirectTo: `${location.pathname}${location.search}`, _csrf: csrfToken },
+			{ method: 'POST', action: '/projects/switch' },
+		);
+	}
+
+	if (projects.length === 0) {
+		return (
+			<SidebarMenu>
+				<SidebarMenuItem>
+					<SidebarMenuButton asChild size='lg' tooltip='New project'>
+						<Link to='/projects/new'>
+							<Plus />
+							<span className='font-medium'>New project</span>
+						</Link>
+					</SidebarMenuButton>
+				</SidebarMenuItem>
+			</SidebarMenu>
+		);
+	}
+
+	return (
+		<SidebarMenu>
+			<SidebarMenuItem>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<SidebarMenuButton size='lg' tooltip={currentProject?.name ?? 'Select a project'}>
+							<div className='grid flex-1 text-left leading-tight'>
+								<span className='truncate font-medium'>{currentProject?.name ?? 'Select a project'}</span>
+								{currentProject && (
+									<span className='truncate text-xs text-muted-foreground'>{currentProject.slug}</span>
+								)}
+							</div>
+
+							<ChevronsUpDown className='ml-auto' />
+						</SidebarMenuButton>
+					</DropdownMenuTrigger>
+
+					<DropdownMenuContent
+						className='w-(--radix-dropdown-menu-trigger-width) min-w-56'
+						align='start'
+						side={isMobile ? 'bottom' : 'right'}
+					>
+						<DropdownMenuLabel className='text-xs text-muted-foreground'>Projects</DropdownMenuLabel>
+
+						{projects.map((project) => (
+							<DropdownMenuItem key={project.id} onSelect={() => switchTo(project.id)}>
+								<span className='truncate'>{project.name}</span>
+								{project.id === currentProject?.id && <Check className='ml-auto' />}
+							</DropdownMenuItem>
+						))}
+
+						<DropdownMenuSeparator />
+
+						<DropdownMenuItem asChild>
+							<Link to='/projects/new'>
+								<Plus />
+								<span>New project</span>
+							</Link>
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</SidebarMenuItem>
+		</SidebarMenu>
+	);
+}

--- a/logwolf-server/frontend/app/lib/api.ts
+++ b/logwolf-server/frontend/app/lib/api.ts
@@ -9,6 +9,13 @@ type ApiKey = {
 	revoked_at: string;
 };
 
+export type Project = {
+	id: string;
+	name: string;
+	slug: string;
+	created_at: string;
+};
+
 export type RetentionDays = 0 | 30 | 60 | 90 | 180 | 365;
 
 export type Metrics = {
@@ -22,6 +29,7 @@ export type Metrics = {
 };
 
 export interface IApi {
+	getProjects(): Promise<Project[]>;
 	getKeys(projectId: string): Promise<ApiKey[]>;
 	createKey(projectId: string): Promise<{ key: string; prefix: string; id: string }>;
 	deleteKey(id: string): Promise<void>;
@@ -43,6 +51,17 @@ export class Api implements IApi {
 			'X-User-Login': this.userLogin,
 			...extra,
 		};
+	}
+
+	public async getProjects(): Promise<Project[]> {
+		const res = await fetch(`${this.baseUrl}projects`, {
+			method: 'GET',
+			headers: this.internalHeaders(),
+		});
+		const json = (await res.json()) as ApiResponse<Project[]>;
+		if (json.error) throw new Error(json.message);
+
+		return json.data;
 	}
 
 	public async getKeys(projectId: string): Promise<ApiKey[]> {

--- a/logwolf-server/frontend/app/lib/session.server.ts
+++ b/logwolf-server/frontend/app/lib/session.server.ts
@@ -7,6 +7,7 @@ type SessionData = {
 		avatarUrl: string;
 	};
 	csrfToken: string;
+	currentProjectID: string;
 };
 
 export const sessionStorage = createCookieSessionStorage<SessionData>({
@@ -21,3 +22,13 @@ export const sessionStorage = createCookieSessionStorage<SessionData>({
 });
 
 export const { getSession, commitSession, destroySession } = sessionStorage;
+
+/**
+ * Reads the project the user is currently working in. Undefined means the user
+ * has no reachable project — the layout loader clears the id whenever the
+ * stored project is gone or the user lost access to it.
+ */
+export async function getCurrentProjectID(request: Request): Promise<string | undefined> {
+	const session = await getSession(request.headers.get('Cookie'));
+	return session.get('currentProjectID');
+}

--- a/logwolf-server/frontend/app/pages/events/details/index.tsx
+++ b/logwolf-server/frontend/app/pages/events/details/index.tsx
@@ -20,7 +20,14 @@ export async function loader({ params, context }: Route.LoaderArgs) {
 	const event = context.get(eventContext);
 	event?.addTag('loader');
 
-	const log = await logwolf.getOne(params.id);
+	// A rejected SDK key reads the same as a missing event here: there is nothing
+	// to show, so fall back to the list rather than a 500.
+	const log = await logwolf.getOne(params.id).catch((err: unknown) => {
+		event?.setSeverity('error');
+		event?.set('loaderError', err);
+
+		return null;
+	});
 	if (!log) throw redirect('/events');
 
 	event?.set('loaderData', ['too much data']);

--- a/logwolf-server/frontend/app/pages/events/index.tsx
+++ b/logwolf-server/frontend/app/pages/events/index.tsx
@@ -3,12 +3,14 @@ import { Plus } from 'lucide-react';
 import { Link } from 'react-router';
 
 import { Page } from '~/components/nav/page';
+import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
 import { Button } from '~/components/ui/button';
 import { Section } from '~/components/ui/section';
 import { eventContext } from '~/context';
 import { useCsrfToken } from '~/hooks/use-csrf-token';
 import { validateCsrfToken } from '~/lib/csrf.server';
 import { logwolf } from '~/lib/logwolf';
+import { getCurrentProjectID } from '~/lib/session.server';
 
 import type { Route } from './+types';
 import { EventsTable } from './components/events-table';
@@ -17,14 +19,27 @@ export function meta() {
 	return [{ title: 'Events - Logwolf' }, { name: 'description', content: 'Logwolf events!' }];
 }
 
-export async function loader({ context }: Route.LoaderArgs) {
+export async function loader({ request, context }: Route.LoaderArgs) {
 	const event = context.get(eventContext);
 	event?.addTag('loader');
 
-	const res = await logwolf.getAll({ page: 1, pageSize: 20 });
-	event?.set('loaderData', ['too much data']);
+	const projectId = await getCurrentProjectID(request);
+	if (!projectId) return { events: [], noProject: true, error: null };
 
-	return res;
+	// Events are still read through the SDK route, which authenticates with its
+	// own API key instead of the dashboard session. A rejected key must not take
+	// the whole page down, so it surfaces as an alert above an empty table.
+	try {
+		const events = await logwolf.getAll({ page: 1, pageSize: 20 });
+		event?.set('loaderData', ['too much data']);
+
+		return { events, noProject: false, error: null };
+	} catch (err) {
+		event?.setSeverity('error');
+		event?.set('loaderError', err);
+
+		return { events: [], noProject: false, error: (err as Error).message };
+	}
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -37,15 +52,32 @@ export async function action({ request, context }: Route.ActionArgs) {
 		await validateCsrfToken(request, fd);
 
 		const data = Object.fromEntries(fd.entries()) as DeleteLogwolfEventDTO;
-		const res = await logwolf.delete(data);
-		event?.set('actionData', res);
 
-		return res;
+		try {
+			const res = await logwolf.delete(data);
+			event?.set('actionData', res);
+
+			return res;
+		} catch (err) {
+			event?.setSeverity('error');
+			event?.set('actionError', err);
+
+			return { error: (err as Error).message };
+		}
 	}
 }
 
 export default function Events({ loaderData }: Route.ComponentProps) {
 	const csrfToken = useCsrfToken();
+	const { events, noProject, error } = loaderData;
+
+	if (noProject) {
+		return (
+			<Page title='Events'>
+				<p className='text-sm text-muted-foreground'>Select a project to view its events.</p>
+			</Page>
+		);
+	}
 
 	return (
 		<Page title='Events'>
@@ -61,7 +93,14 @@ export default function Events({ loaderData }: Route.ComponentProps) {
 						</Link>
 					}
 				>
-					<EventsTable events={loaderData} csrfToken={csrfToken} />
+					{error && (
+						<Alert variant='destructive' className='mb-4'>
+							<AlertTitle>Could not load events</AlertTitle>
+							<AlertDescription>{error}</AlertDescription>
+						</Alert>
+					)}
+
+					<EventsTable events={events} csrfToken={csrfToken} />
 				</Section>
 			</div>
 		</Page>

--- a/logwolf-server/frontend/app/pages/layout.tsx
+++ b/logwolf-server/frontend/app/pages/layout.tsx
@@ -3,28 +3,60 @@ import { data, Outlet, redirect } from 'react-router';
 import { AppSidebar } from '~/components/nav/app-sidebar';
 import { SidebarProvider } from '~/components/ui/sidebar';
 import { Toaster } from '~/components/ui/sonner';
+import { eventContext } from '~/context';
+import { createApi } from '~/lib/api';
+import { requireAuth } from '~/lib/auth.server';
 import { getOrCreateCsrfToken } from '~/lib/csrf.server';
 import { commitSession, getSession } from '~/lib/session.server';
 import { ThemeProvider } from '~/store/theme-provider';
 
-import type { Route } from '../+types/root';
+import type { Route } from './+types/layout';
 
-export async function loader({ request }: Route.LoaderArgs) {
+export async function loader({ request, context }: Route.LoaderArgs) {
+	const event = context.get(eventContext);
+	event?.addTag('loader');
+
+	const user = await requireAuth(request);
+
 	const session = await getSession(request.headers.get('Cookie'));
-
-	const user = session.get('githubUser');
-	if (!user) throw redirect('/auth');
-
 	const csrfToken = getOrCreateCsrfToken(session);
 
-	return data({ user, csrfToken }, { headers: { 'Set-Cookie': await commitSession(session) } });
+	const api = createApi(user.login);
+	const projects = await api.getProjects();
+
+	// The stored project is only usable while the user is still a member of it —
+	// a deleted project, or one the user was removed from, falls back to the
+	// first project they can still reach.
+	const storedProjectID = session.get('currentProjectID');
+	const currentProject = projects.find((p) => p.id === storedProjectID) ?? projects.at(0);
+
+	if (currentProject?.id !== storedProjectID) {
+		if (currentProject) session.set('currentProjectID', currentProject.id);
+		else session.unset('currentProjectID');
+
+		// Child loaders of this request already read the stale cookie, so reload
+		// the same URL to let them run against the corrected session.
+		const url = new URL(request.url);
+		throw redirect(`${url.pathname}${url.search}`, {
+			headers: { 'Set-Cookie': await commitSession(session) },
+		});
+	}
+
+	event?.set('currentProjectID', currentProject?.id ?? null);
+
+	return data(
+		{ user, csrfToken, projects, currentProject },
+		{ headers: { 'Set-Cookie': await commitSession(session) } },
+	);
 }
 
-export default function Layout({ matches }: Route.ComponentProps) {
+export default function Layout({ matches, loaderData }: Route.ComponentProps) {
+	const { projects, currentProject, csrfToken } = loaderData;
+
 	return (
 		<ThemeProvider>
 			<SidebarProvider>
-				<AppSidebar matches={matches} />
+				<AppSidebar matches={matches} projects={projects} currentProject={currentProject} csrfToken={csrfToken} />
 
 				<main className='flex px-4 py-4 w-full'>
 					<Outlet />

--- a/logwolf-server/frontend/app/pages/projects/switch/index.tsx
+++ b/logwolf-server/frontend/app/pages/projects/switch/index.tsx
@@ -1,0 +1,56 @@
+import { redirect } from 'react-router';
+
+import { eventContext } from '~/context';
+import { createApi } from '~/lib/api';
+import { requireAuth } from '~/lib/auth.server';
+import { validateCsrfToken } from '~/lib/csrf.server';
+import { commitSession, getSession } from '~/lib/session.server';
+
+import type { Route } from './+types';
+
+const FALLBACK_REDIRECT = '/dashboard';
+
+/**
+ * Keeps the caller-supplied redirect target on this origin — an absolute URL or
+ * a protocol-relative path would turn the switcher into an open redirect.
+ */
+function safeRedirect(to: string | undefined): string {
+	if (!to?.startsWith('/') || to.startsWith('//') || to.startsWith('/\\')) return FALLBACK_REDIRECT;
+	return to;
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+	const event = context.get(eventContext);
+	event?.addTag('action');
+
+	const user = await requireAuth(request);
+	const fd = await request.formData();
+
+	await validateCsrfToken(request, fd);
+
+	const projectId = fd.get('projectId')?.toString() ?? '';
+	const redirectTo = safeRedirect(fd.get('redirectTo')?.toString());
+	event?.set('projectId', projectId);
+
+	// The id comes from the browser, so membership is re-checked here. A project
+	// the user can no longer reach — deleted, or one they were removed from —
+	// leaves the session alone; the layout loader re-points it on the way back.
+	const api = createApi(user.login);
+	const projects = await api.getProjects();
+
+	if (!projects.some((p) => p.id === projectId)) {
+		event?.setSeverity('warning');
+		event?.set('switchRejected', 'not a member');
+		return redirect(redirectTo);
+	}
+
+	const session = await getSession(request.headers.get('Cookie'));
+	session.set('currentProjectID', projectId);
+
+	return redirect(redirectTo, { headers: { 'Set-Cookie': await commitSession(session) } });
+}
+
+// Switching is a POST-only action; a stray GET has nothing to render.
+export async function loader() {
+	return redirect(FALLBACK_REDIRECT);
+}

--- a/logwolf-server/frontend/app/routes.ts
+++ b/logwolf-server/frontend/app/routes.ts
@@ -4,6 +4,8 @@ export default [
 	index('pages/home/index.tsx'),
 	route('auth', 'pages/auth/index.tsx'),
 
+	route('projects/switch', 'pages/projects/switch/index.tsx'),
+
 	layout('pages/layout.tsx', [
 		route('dashboard', 'pages/dashboard/index.tsx'),
 		route('events', 'pages/events/index.tsx'),


### PR DESCRIPTION
Closes #14.

## What

Phase 4, part one: the session now remembers which project the user is working in, and the sidebar gets a switcher to change it.

- **Session** — `SessionData` gains `currentProjectID`, plus a `getCurrentProjectID(request)` helper.
- **Layout loader** — fetches the user's projects via `GET /projects`, drops the stored id when the project is gone or the user lost access to it, auto-selects the first reachable project, and passes `user`, `csrfToken`, `projects`, and `currentProject` down. When it re-points the session it redirects to the same URL, so child loaders run against the corrected cookie instead of the stale one they were handed.
- **Sidebar** — static header replaced by a project dropdown (active project, full list with a check on the current one, and a "New project" entry pointing at `/projects/new`, which lands in #15). With no projects it collapses to a single "New project" call to action.
- **`/projects/switch`** — POST-only action. Validates CSRF, re-checks membership server-side (the id comes from the browser), writes the session, and redirects back to the originating page so every loader revalidates. A switch to a project the user can no longer reach leaves the session untouched and redirects back, where the layout re-points it.
- **API client** — adds `Project` and `getProjects()`.

## Drive-by fix

`/events` returned a 500 whenever the SDK key was rejected — it is the one page still reading through the public SDK route rather than the internal API, so it had none of the `noProject` guards its siblings got in Phase 3. It now shows the same empty state as the other pages, and a rejected key renders an alert over an empty table instead of taking the page down. `/events/:id` and the delete action had the identical crash path and are guarded too.

Routing `/events` through the internal project-scoped API is #17 and needs a new broker route, so it is not attempted here.

## Notes for review

- Based on `feat/multi-tenancy`, not `main` — `GET /projects` does not exist on `main`.
- Open-redirect guard on `redirectTo` rejects absolute, protocol-relative, and backslash-prefixed targets.
- Pages still read `?projectId=` from the query string; migrating them to the session is #17.

## Verification

`npm run typecheck`, `oxlint`, and `oxfmt --check` are clean on every touched file. Verified live against the local Docker stack: `/events` no longer 500s with no active project.
