### PR TITLE
feat(#16): project settings page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,11 @@ Key files: `lib/client.ts` (Logwolf class), `lib/schema.ts` (Zod schemas), `lib/
 
 Key files: `app/root.tsx`, `app/lib/api.ts` (dashboard API client), `app/lib/auth.server.ts`.
 
-Routes: `/` (public), `/auth`, `/dashboard`, `/events`, `/events/create`, `/events/:id`, `/keys`, `/settings`, `/projects`, `/projects/new`, `/projects/switch`.
+Routes: `/` (public), `/auth`, `/dashboard`, `/events`, `/events/create`, `/events/:id`, `/keys`, `/projects`, `/projects/new`, `/projects/switch`, `/projects/:id/settings`. `/settings` is a redirect to the current project's settings page.
 
 The layout loader keeps `currentProjectID` in the session honest and redirects a user with no projects to `/projects/new`, the only protected page that renders without a current project.
+
+Project name, retention, members and deletion all live on `/projects/:id/settings`. Retention is editable by any member; renaming, member changes and deletion are owner-only, enforced in the broker and mirrored in the route so the UI can explain itself.
 
 `lib/api.ts` → calls Broker internal routes via `X-Internal-Secret`. Never calls public SDK routes.
 

--- a/logwolf-server/frontend/app/components/nav/app-sidebar.tsx
+++ b/logwolf-server/frontend/app/components/nav/app-sidebar.tsx
@@ -36,12 +36,6 @@ const items = [
 		url: '/keys',
 		icon: KeyRound,
 	},
-
-	{
-		title: 'Settings',
-		url: '/settings',
-		icon: Settings,
-	},
 ] as const;
 
 type Props = Pick<Route.ComponentProps, 'matches'> & {
@@ -50,6 +44,18 @@ type Props = Pick<Route.ComponentProps, 'matches'> & {
 	csrfToken: string;
 };
 export function AppSidebar({ matches, projects, currentProject, csrfToken }: Props) {
+	// Settings live under the project they configure. /settings still forwards
+	// there, but linking straight at the project keeps the item highlighted once
+	// the page is open.
+	const navItems = [
+		...items,
+		{
+			title: 'Settings',
+			url: currentProject ? `/projects/${currentProject.id}/settings` : '/settings',
+			icon: Settings,
+		},
+	];
+
 	return (
 		<Sidebar>
 			<SidebarHeader>
@@ -62,7 +68,7 @@ export function AppSidebar({ matches, projects, currentProject, csrfToken }: Pro
 
 					<SidebarGroupContent>
 						<SidebarMenu>
-							{items.map((item) => (
+							{navItems.map((item) => (
 								<SidebarMenuItem key={item.title}>
 									<SidebarMenuButton asChild isActive={matches.some((m) => m?.pathname.includes(item.url))}>
 										<Link to={item.url}>

--- a/logwolf-server/frontend/app/lib/api.ts
+++ b/logwolf-server/frontend/app/lib/api.ts
@@ -21,6 +21,15 @@ export type ProjectRole = 'owner' | 'member';
 /** A project together with the role the requesting user holds in it. */
 export type UserProject = Project & { role: ProjectRole };
 
+/** A row of the project_members collection, as returned by the broker. */
+export type ProjectMember = {
+	id: string;
+	project_id: string;
+	github_login: string;
+	role: ProjectRole;
+	created_at: string;
+};
+
 export type RetentionDays = 0 | 30 | 60 | 90 | 180 | 365;
 
 export type Metrics = {
@@ -36,6 +45,11 @@ export type Metrics = {
 export interface IApi {
 	getProjects(): Promise<UserProject[]>;
 	createProject(name: string, slug: string): Promise<Project>;
+	updateProject(id: string, name: string, slug: string): Promise<Project>;
+	deleteProject(id: string): Promise<void>;
+	getMembers(projectId: string): Promise<ProjectMember[]>;
+	addMember(projectId: string, login: string, role: ProjectRole): Promise<void>;
+	removeMember(projectId: string, login: string): Promise<void>;
 	getKeys(projectId: string): Promise<ApiKey[]>;
 	createKey(projectId: string): Promise<{ key: string; prefix: string; id: string }>;
 	deleteKey(id: string): Promise<void>;
@@ -80,6 +94,59 @@ export class Api implements IApi {
 		if (json.error) throw new Error(json.message);
 
 		return json.data;
+	}
+
+	public async updateProject(id: string, name: string, slug: string): Promise<Project> {
+		const res = await fetch(`${this.baseUrl}projects/${id}`, {
+			method: 'PATCH',
+			headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
+			body: JSON.stringify({ name, slug }),
+		});
+		const json = (await res.json()) as ApiResponse<Project>;
+		if (json.error) throw new Error(json.message);
+
+		return json.data;
+	}
+
+	public async deleteProject(id: string): Promise<void> {
+		const res = await fetch(`${this.baseUrl}projects/${id}`, {
+			method: 'DELETE',
+			headers: this.internalHeaders(),
+		});
+		const json = (await res.json()) as ApiResponse<void>;
+		if (json.error) throw new Error(json.message);
+	}
+
+	public async getMembers(projectId: string): Promise<ProjectMember[]> {
+		const res = await fetch(`${this.baseUrl}projects/${projectId}/members`, {
+			method: 'GET',
+			headers: this.internalHeaders(),
+		});
+		const json = (await res.json()) as ApiResponse<ProjectMember[]>;
+		if (json.error) throw new Error(json.message);
+
+		return json.data ?? [];
+	}
+
+	public async addMember(projectId: string, login: string, role: ProjectRole): Promise<void> {
+		const res = await fetch(`${this.baseUrl}projects/${projectId}/members`, {
+			method: 'POST',
+			headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
+			body: JSON.stringify({ login, role }),
+		});
+		const json = (await res.json()) as ApiResponse<void>;
+		if (json.error) throw new Error(json.message);
+	}
+
+	public async removeMember(projectId: string, login: string): Promise<void> {
+		// GitHub logins are URL-safe, but the value reaches us from a form field —
+		// encoding it keeps a hand-crafted login from reshaping the path.
+		const res = await fetch(`${this.baseUrl}projects/${projectId}/members/${encodeURIComponent(login)}`, {
+			method: 'DELETE',
+			headers: this.internalHeaders(),
+		});
+		const json = (await res.json()) as ApiResponse<void>;
+		if (json.error) throw new Error(json.message);
 	}
 
 	public async getKeys(projectId: string): Promise<ApiKey[]> {

--- a/logwolf-server/frontend/app/pages/projects/settings/action-result.ts
+++ b/logwolf-server/frontend/app/pages/projects/settings/action-result.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Every intent on the project settings action answers with the same shape, so
+ * each section can type its own fetcher without importing the route module.
+ */
+export type SettingsActionResult = { error?: string; success?: string } | null;
+
+/** Announces a settings change once, when the fetcher comes back with one. */
+export function useSuccessToast(result: SettingsActionResult | undefined) {
+	useEffect(() => {
+		if (result?.success) toast(result.success);
+	}, [result]);
+}

--- a/logwolf-server/frontend/app/pages/projects/settings/components/danger-zone.tsx
+++ b/logwolf-server/frontend/app/pages/projects/settings/components/danger-zone.tsx
@@ -1,0 +1,111 @@
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useFetcher } from 'react-router';
+
+import { Alert, AlertTitle } from '~/components/ui/alert';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent } from '~/components/ui/card';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '~/components/ui/dialog';
+import { Field, FieldGroup, FieldLabel } from '~/components/ui/field';
+import { Input } from '~/components/ui/input';
+import { Section } from '~/components/ui/section';
+import { useCsrfToken } from '~/hooks/use-csrf-token';
+import type { UserProject } from '~/lib/api';
+
+import type { SettingsActionResult } from '../action-result';
+
+type Props = { project: UserProject };
+
+export function DangerZone({ project }: Props) {
+	const csrfToken = useCsrfToken();
+	const fetcher = useFetcher<SettingsActionResult>();
+
+	const [open, setOpen] = useState(false);
+	const [confirmation, setConfirmation] = useState('');
+
+	// A successful delete redirects, so there is no success state to report here
+	// — only the mismatch and whatever the broker refuses.
+	const confirmed = confirmation === project.name;
+
+	function onOpenChange(next: boolean) {
+		setOpen(next);
+		if (!next) setConfirmation('');
+	}
+
+	return (
+		<Section title='Danger zone'>
+			<Card className='shadow-none max-w-md border-destructive/50'>
+				<CardContent className='flex flex-col gap-3'>
+					<div className='flex flex-col gap-1'>
+						<span className='text-sm font-medium'>Delete this project</span>
+						<span className='text-sm text-muted-foreground'>
+							Its events, API keys and members go with it. This cannot be undone.
+						</span>
+					</div>
+
+					{fetcher.data?.error && (
+						<Alert variant='destructive'>
+							<AlertTitle>{fetcher.data.error}</AlertTitle>
+						</Alert>
+					)}
+
+					<Button variant='destructive' className='w-fit' onClick={() => onOpenChange(true)}>
+						<Trash2 />
+						Delete project
+					</Button>
+				</CardContent>
+			</Card>
+
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete {project.name}?</DialogTitle>
+						<DialogDescription>
+							This deletes the project along with every event, API key and membership in it.
+						</DialogDescription>
+					</DialogHeader>
+
+					<fetcher.Form method='post'>
+						<FieldGroup>
+							<input type='hidden' name='_csrf' value={csrfToken} />
+							<input type='hidden' name='intent' value='delete' />
+
+							<Field>
+								<FieldLabel htmlFor='confirmation'>
+									Type <code>{project.name}</code> to confirm
+								</FieldLabel>
+
+								<Input
+									id='confirmation'
+									name='confirmation'
+									type='text'
+									autoComplete='off'
+									value={confirmation}
+									onChange={(e) => setConfirmation(e.target.value)}
+								/>
+							</Field>
+
+							<DialogFooter>
+								<Button type='button' variant='outline' onClick={() => onOpenChange(false)}>
+									Cancel
+								</Button>
+
+								<Button type='submit' variant='destructive' disabled={!confirmed || fetcher.state !== 'idle'}>
+									<Trash2 />
+									Delete project
+								</Button>
+							</DialogFooter>
+						</FieldGroup>
+					</fetcher.Form>
+				</DialogContent>
+			</Dialog>
+		</Section>
+	);
+}

--- a/logwolf-server/frontend/app/pages/projects/settings/components/general-section.tsx
+++ b/logwolf-server/frontend/app/pages/projects/settings/components/general-section.tsx
@@ -1,0 +1,73 @@
+import { Check } from 'lucide-react';
+import { useFetcher } from 'react-router';
+
+import { Alert, AlertTitle } from '~/components/ui/alert';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent } from '~/components/ui/card';
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '~/components/ui/field';
+import { Input } from '~/components/ui/input';
+import { Section } from '~/components/ui/section';
+import { useCsrfToken } from '~/hooks/use-csrf-token';
+import type { UserProject } from '~/lib/api';
+
+import { type SettingsActionResult, useSuccessToast } from '../action-result';
+
+type Props = { project: UserProject; canEdit: boolean };
+
+export function GeneralSection({ project, canEdit }: Props) {
+	const csrfToken = useCsrfToken();
+	const fetcher = useFetcher<SettingsActionResult>();
+	useSuccessToast(fetcher.data);
+
+	return (
+		<Section title='General'>
+			<Card className='shadow-none max-w-md'>
+				<CardContent>
+					<fetcher.Form method='post'>
+						<FieldGroup>
+							{fetcher.data?.error && (
+								<Alert variant='destructive'>
+									<AlertTitle>{fetcher.data.error}</AlertTitle>
+								</Alert>
+							)}
+
+							<input type='hidden' name='_csrf' value={csrfToken} />
+							<input type='hidden' name='intent' value='rename' />
+
+							<Field>
+								<FieldLabel htmlFor='name'>Name</FieldLabel>
+
+								{/* Keyed on the project so opening another project's settings
+								    doesn't leave the previous name in an uncontrolled input. */}
+								<Input
+									key={project.id}
+									id='name'
+									name='name'
+									type='text'
+									defaultValue={project.name}
+									disabled={!canEdit}
+									required
+								/>
+
+								<FieldDescription>
+									Slug: <code>{project.slug}</code> — set when the project was created and fixed after that.
+								</FieldDescription>
+							</Field>
+
+							{canEdit ? (
+								<Field className='flex flex-row justify-end items-end'>
+									<Button type='submit' disabled={fetcher.state !== 'idle'} className='w-fit'>
+										<Check />
+										Save
+									</Button>
+								</Field>
+							) : (
+								<FieldDescription>Only an owner can rename this project.</FieldDescription>
+							)}
+						</FieldGroup>
+					</fetcher.Form>
+				</CardContent>
+			</Card>
+		</Section>
+	);
+}

--- a/logwolf-server/frontend/app/pages/projects/settings/components/members-section.tsx
+++ b/logwolf-server/frontend/app/pages/projects/settings/components/members-section.tsx
@@ -1,0 +1,160 @@
+import { Plus, Trash2 } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { useFetcher } from 'react-router';
+
+import { Alert, AlertTitle } from '~/components/ui/alert';
+import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent } from '~/components/ui/card';
+import { Field, FieldGroup, FieldLabel } from '~/components/ui/field';
+import { Input } from '~/components/ui/input';
+import { Section } from '~/components/ui/section';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table';
+import { useCsrfToken } from '~/hooks/use-csrf-token';
+import type { ProjectMember } from '~/lib/api';
+
+import { type SettingsActionResult, useSuccessToast } from '../action-result';
+
+type Props = { members: ProjectMember[]; currentUser: string; canManage: boolean };
+
+export function MembersSection({ members, currentUser, canManage }: Props) {
+	const csrfToken = useCsrfToken();
+
+	// Adding and removing get their own fetchers so a pending removal doesn't
+	// grey out the add form, and each reports its own error where it happened.
+	const addFetcher = useFetcher<SettingsActionResult>();
+	const removeFetcher = useFetcher<SettingsActionResult>();
+
+	useSuccessToast(addFetcher.data);
+	useSuccessToast(removeFetcher.data);
+
+	const addFormRef = useRef<HTMLFormElement>(null);
+
+	// The fetcher revalidates the table on its own, but the login it just added
+	// would otherwise stay in the box waiting to be added a second time.
+	useEffect(() => {
+		if (addFetcher.data?.success) addFormRef.current?.reset();
+	}, [addFetcher.data]);
+
+	// A project must always keep one owner, so the last one has no Remove button.
+	// The broker refuses the call too; this only saves the round trip.
+	const ownerCount = members.filter((m) => m.role === 'owner').length;
+	const removing = removeFetcher.formData?.get('login')?.toString();
+
+	return (
+		<Section title='Members'>
+			<div className='flex flex-col gap-2'>
+				{(addFetcher.data?.error || removeFetcher.data?.error) && (
+					<Alert variant='destructive'>
+						<AlertTitle>{addFetcher.data?.error ?? removeFetcher.data?.error}</AlertTitle>
+					</Alert>
+				)}
+
+				<Card className='shadow-none'>
+					<CardContent>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Member</TableHead>
+									<TableHead>Role</TableHead>
+									<TableHead>Joined</TableHead>
+									{canManage && <TableHead className='w-0' />}
+								</TableRow>
+							</TableHeader>
+
+							<TableBody>
+								{members.map((member) => {
+									const isLastOwner = member.role === 'owner' && ownerCount === 1;
+
+									return (
+										<TableRow key={member.id}>
+											<TableCell className='font-medium'>
+												{member.github_login}
+												{member.github_login === currentUser && (
+													<span className='ml-2 text-xs text-muted-foreground'>(you)</span>
+												)}
+											</TableCell>
+
+											<TableCell>
+												<Badge variant={member.role === 'owner' ? 'default' : 'secondary'}>{member.role}</Badge>
+											</TableCell>
+
+											<TableCell className='text-muted-foreground'>
+												{new Date(member.created_at).toLocaleDateString()}
+											</TableCell>
+
+											{canManage && (
+												<TableCell>
+													{isLastOwner ? (
+														<span className='text-xs text-muted-foreground whitespace-nowrap'>Last owner</span>
+													) : (
+														<removeFetcher.Form method='post'>
+															<input type='hidden' name='_csrf' value={csrfToken} />
+															<input type='hidden' name='intent' value='remove-member' />
+															<input type='hidden' name='login' value={member.github_login} />
+
+															<Button
+																type='submit'
+																variant='ghost'
+																size='icon-sm'
+																aria-label={`Remove ${member.github_login}`}
+																disabled={removing === member.github_login}
+															>
+																<Trash2 />
+															</Button>
+														</removeFetcher.Form>
+													)}
+												</TableCell>
+											)}
+										</TableRow>
+									);
+								})}
+							</TableBody>
+						</Table>
+					</CardContent>
+				</Card>
+
+				{canManage && (
+					<Card className='shadow-none max-w-xl'>
+						<CardContent>
+							<addFetcher.Form method='post' ref={addFormRef}>
+								<FieldGroup>
+									<input type='hidden' name='_csrf' value={csrfToken} />
+									<input type='hidden' name='intent' value='add-member' />
+
+									<div className='flex flex-row items-end gap-3'>
+										<Field className='flex-1'>
+											<FieldLabel htmlFor='login'>GitHub login</FieldLabel>
+											<Input id='login' name='login' type='text' placeholder='octocat' required />
+										</Field>
+
+										<Field className='w-32'>
+											<FieldLabel htmlFor='role'>Role</FieldLabel>
+
+											<Select name='role' defaultValue='member'>
+												<SelectTrigger id='role' className='w-full'>
+													<SelectValue placeholder='Role' />
+												</SelectTrigger>
+
+												<SelectContent>
+													<SelectItem value='member'>member</SelectItem>
+													<SelectItem value='owner'>owner</SelectItem>
+												</SelectContent>
+											</Select>
+										</Field>
+
+										<Button type='submit' disabled={addFetcher.state !== 'idle'}>
+											<Plus />
+											Add
+										</Button>
+									</div>
+								</FieldGroup>
+							</addFetcher.Form>
+						</CardContent>
+					</Card>
+				)}
+			</div>
+		</Section>
+	);
+}

--- a/logwolf-server/frontend/app/pages/projects/settings/components/retention-section.tsx
+++ b/logwolf-server/frontend/app/pages/projects/settings/components/retention-section.tsx
@@ -1,0 +1,95 @@
+import { Check } from 'lucide-react';
+import { useFetcher } from 'react-router';
+
+import { Alert, AlertTitle } from '~/components/ui/alert';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent } from '~/components/ui/card';
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '~/components/ui/field';
+import { Section } from '~/components/ui/section';
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from '~/components/ui/select';
+import { useCsrfToken } from '~/hooks/use-csrf-token';
+import type { RetentionDays } from '~/lib/api';
+
+import { type SettingsActionResult, useSuccessToast } from '../action-result';
+
+type RetentionDaysMap<T extends number> = {
+	[P in T as `${P}`]: string;
+};
+
+const retentionDaysMap: RetentionDaysMap<RetentionDays> = {
+	0: 'Forever',
+	30: '30 days',
+	60: '60 days',
+	90: '90 days',
+	180: '180 days',
+	365: '365 days',
+};
+
+const retentionOptions = Object.entries(retentionDaysMap);
+
+type Props = { days: RetentionDays };
+
+export function RetentionSection({ days }: Props) {
+	const csrfToken = useCsrfToken();
+	const fetcher = useFetcher<SettingsActionResult>();
+	useSuccessToast(fetcher.data);
+
+	return (
+		<Section title='Data retention'>
+			<Card className='shadow-none max-w-md'>
+				<CardContent>
+					<fetcher.Form method='post'>
+						<FieldGroup>
+							{fetcher.data?.error && (
+								<Alert variant='destructive'>
+									<AlertTitle>{fetcher.data.error}</AlertTitle>
+								</Alert>
+							)}
+
+							<input type='hidden' name='_csrf' value={csrfToken} />
+							<input type='hidden' name='intent' value='retention' />
+
+							<Field>
+								<FieldLabel>Retention time</FieldLabel>
+
+								<Select name='days' defaultValue={days.toString()}>
+									<SelectTrigger className='w-full'>
+										<SelectValue placeholder='Retention days' />
+									</SelectTrigger>
+
+									<SelectContent>
+										<SelectGroup>
+											<SelectLabel>Retention time</SelectLabel>
+											{retentionOptions.map(([value, label]) => (
+												<SelectItem key={value} value={value}>
+													{label}
+												</SelectItem>
+											))}
+										</SelectGroup>
+									</SelectContent>
+								</Select>
+
+								<FieldDescription>Events older than this are dropped from this project.</FieldDescription>
+							</Field>
+
+							<Field className='flex flex-row justify-end items-end'>
+								<Button type='submit' disabled={fetcher.state !== 'idle'} className='w-fit'>
+									<Check />
+									Save
+								</Button>
+							</Field>
+						</FieldGroup>
+					</fetcher.Form>
+				</CardContent>
+			</Card>
+		</Section>
+	);
+}

--- a/logwolf-server/frontend/app/pages/projects/settings/index.tsx
+++ b/logwolf-server/frontend/app/pages/projects/settings/index.tsx
@@ -1,0 +1,139 @@
+import { redirect } from 'react-router';
+
+import { Page } from '~/components/nav/page';
+import { eventContext } from '~/context';
+import { createApi } from '~/lib/api';
+import { requireAuth } from '~/lib/auth.server';
+import { validateCsrfToken } from '~/lib/csrf.server';
+import { commitSession, getSession } from '~/lib/session.server';
+
+import type { Route } from './+types';
+import { DangerZone } from './components/danger-zone';
+import { GeneralSection } from './components/general-section';
+import { MembersSection } from './components/members-section';
+import { RetentionSection } from './components/retention-section';
+
+export function meta({ data }: Route.MetaArgs) {
+	return [{ title: `${data?.project.name ?? 'Project'} settings - Logwolf` }];
+}
+
+/**
+ * Resolves the project in the URL against the projects the caller belongs to.
+ * One list call answers both "may they open this page?" and "what role do they
+ * hold?" — the broker would reject a non-member anyway, but as a 403 that only
+ * the error boundary could render.
+ */
+async function requireProject(request: Request, id: string | undefined) {
+	const user = await requireAuth(request);
+	const api = createApi(user.login);
+
+	const projects = await api.getProjects();
+	const project = projects.find((p) => p.id === id);
+	if (!project) throw redirect('/projects');
+
+	return { user, api, project };
+}
+
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+	const event = context.get(eventContext);
+	event?.addTag('loader');
+
+	const { user, api, project } = await requireProject(request, params.id);
+
+	const [members, retention] = await Promise.all([api.getMembers(project.id), api.getRetention(project.id)]);
+	event?.set('loaderData', { project, memberCount: members.length, days: retention.days });
+
+	return { project, members, days: retention.days, currentUser: user.login };
+}
+
+export async function action({ request, params, context }: Route.ActionArgs) {
+	const event = context.get(eventContext);
+	event?.addTag('action');
+
+	const { api, project } = await requireProject(request, params.id);
+
+	const fd = await request.formData();
+	await validateCsrfToken(request, fd);
+
+	const intent = fd.get('intent')?.toString() ?? '';
+	event?.set('intent', intent);
+
+	// Retention is the one setting any member may change; the broker enforces
+	// the same split, but repeating it here turns a bare "forbidden" from a
+	// stale tab into a message the page can show next to the control.
+	if (intent !== 'retention' && project.role !== 'owner') {
+		return { error: 'Only an owner can change this.' };
+	}
+
+	try {
+		if (intent === 'rename') {
+			const name = fd.get('name')?.toString().trim() ?? '';
+			if (!name) return { error: 'Name is required.' };
+
+			// The slug is fixed at creation, so the stored one goes back unchanged —
+			// the broker rejects an update that carries no valid slug.
+			await api.updateProject(project.id, name, project.slug);
+			return { success: `Renamed to ${name}.` };
+		}
+
+		if (intent === 'retention') {
+			const days = Number(fd.get('days'));
+			const res = await api.updateRetention(project.id, days);
+			event?.set('actionData', res);
+			return { success: 'Retention updated.' };
+		}
+
+		if (intent === 'add-member') {
+			const login = fd.get('login')?.toString().trim() ?? '';
+			const role = fd.get('role')?.toString() === 'owner' ? 'owner' : 'member';
+			if (!login) return { error: 'A GitHub login is required.' };
+
+			await api.addMember(project.id, login, role);
+			return { success: `Added ${login} as ${role}.` };
+		}
+
+		if (intent === 'remove-member') {
+			const login = fd.get('login')?.toString() ?? '';
+			await api.removeMember(project.id, login);
+			return { success: `Removed ${login}.` };
+		}
+
+		if (intent === 'delete') {
+			// The dialog disables its button until the typed name matches, but the
+			// check that counts is this one — a form post never sees that button.
+			const confirmation = fd.get('confirmation')?.toString() ?? '';
+			if (confirmation !== project.name) return { error: 'The project name does not match.' };
+
+			await api.deleteProject(project.id);
+
+			const session = await getSession(request.headers.get('Cookie'));
+			if (session.get('currentProjectID') === project.id) session.unset('currentProjectID');
+
+			// /projects renders inside the layout, which forwards to /projects/new
+			// when the project just deleted was the caller's last one.
+			return redirect('/projects', { headers: { 'Set-Cookie': await commitSession(session) } });
+		}
+
+		return null;
+	} catch (err) {
+		event?.setSeverity('error');
+		event?.set('actionError', err);
+		return { error: (err as Error).message };
+	}
+}
+
+export default function ProjectSettings({ loaderData }: Route.ComponentProps) {
+	const { project, members, days, currentUser } = loaderData;
+	const isOwner = project.role === 'owner';
+
+	return (
+		<Page title={`${project.name} settings`}>
+			<div className='flex flex-col gap-8'>
+				<GeneralSection project={project} canEdit={isOwner} />
+				<RetentionSection days={days} />
+				<MembersSection members={members} currentUser={currentUser} canManage={isOwner} />
+				{isOwner && <DangerZone project={project} />}
+			</div>
+		</Page>
+	);
+}

--- a/logwolf-server/frontend/app/pages/settings/index.tsx
+++ b/logwolf-server/frontend/app/pages/settings/index.tsx
@@ -1,166 +1,24 @@
-import { Check } from 'lucide-react';
-import { useFetcher } from 'react-router';
-import { toast } from 'sonner';
+import { redirect } from 'react-router';
 
-import { Page } from '~/components/nav/page';
-import { Alert, AlertTitle } from '~/components/ui/alert';
-import { Button } from '~/components/ui/button';
-import { Card, CardContent } from '~/components/ui/card';
-import { Field, FieldGroup, FieldLabel } from '~/components/ui/field';
-import { Section } from '~/components/ui/section';
-import {
-	Select,
-	SelectContent,
-	SelectGroup,
-	SelectItem,
-	SelectLabel,
-	SelectTrigger,
-	SelectValue,
-} from '~/components/ui/select';
 import { eventContext } from '~/context';
-import { useCsrfToken } from '~/hooks/use-csrf-token';
-import { createApi, type RetentionDays } from '~/lib/api';
 import { requireAuth } from '~/lib/auth.server';
-import { validateCsrfToken } from '~/lib/csrf.server';
+import { getCurrentProjectID } from '~/lib/session.server';
 
 import type { Route } from './+types';
 
-type RetentionDaysMap<T extends number> = {
-	[P in T as `${P}`]: string;
-};
-
-const retentionDaysMap: RetentionDaysMap<RetentionDays> = {
-	0: 'Forever',
-	30: '30 days',
-	60: '60 days',
-	90: '90 days',
-	180: '180 days',
-	365: '365 days',
-};
-
+/**
+ * Settings moved under the project they configure. This path stays behind as a
+ * forward so bookmarks — and anything still linking to /settings — land on the
+ * settings of whichever project the session is currently pointed at.
+ */
 export async function loader({ request, context }: Route.LoaderArgs) {
 	const event = context.get(eventContext);
 	event?.addTag('loader');
 
-	const user = await requireAuth(request);
-	const projectId = new URL(request.url).searchParams.get('projectId') ?? '';
+	await requireAuth(request);
 
-	if (!projectId) {
-		return { days: 90 as RetentionDays, projectId: '', noProject: true };
-	}
+	const projectId = await getCurrentProjectID(request);
+	if (!projectId) return redirect('/projects/new');
 
-	const api = createApi(user.login);
-	const res = await api.getRetention(projectId);
-	event?.set('loaderData', res);
-
-	return { ...res, projectId, noProject: false };
-}
-
-export async function action({ request, context }: Route.ActionArgs) {
-	const event = context.get(eventContext);
-	event?.addTag('action');
-
-	try {
-		const user = await requireAuth(request);
-		const fd = await request.formData();
-
-		await validateCsrfToken(request, fd);
-
-		const intent = fd.get('intent');
-		event?.set('intent', intent);
-
-		if (intent === 'update') {
-			const days = fd.get('days');
-			const projectId = fd.get('projectId')?.toString() ?? '';
-			const api = createApi(user.login);
-			const res = await api.updateRetention(projectId, +days!);
-			event?.set('actionData', res);
-			return { data: res };
-		}
-
-		return null;
-	} catch (err) {
-		event?.setSeverity('error');
-		event?.set('actionError', err);
-		return { error: err as Error };
-	}
-}
-
-export function meta() {
-	return [{ title: 'Settings - Logwolf' }];
-}
-
-type FetcherData = Awaited<ReturnType<typeof action>>;
-
-export default function Settings({ loaderData }: Route.ComponentProps) {
-	const csrfToken = useCsrfToken();
-	const fetcher = useFetcher<FetcherData>();
-	const actionData = fetcher.data;
-
-	if (actionData?.data) toast('Updated retention days: ' + retentionDaysMap[actionData.data.days]);
-
-	if (loaderData.noProject) {
-		return (
-			<Page title='Settings'>
-				<p className='text-sm text-muted-foreground'>Select a project to manage its settings.</p>
-			</Page>
-		);
-	}
-
-	return (
-		<Page title='Settings'>
-			<div className='flex flex-col gap-8'>
-				<Section title='Settings'>
-					<div className='flex flex-col gap-2'>
-						<Card className='shadow-none max-w-md'>
-							<CardContent className='flex flex-col py-3'>
-								<fetcher.Form method='post' className='w-full'>
-									<FieldGroup>
-										{actionData?.error && (
-											<Alert>
-												<AlertTitle>{actionData.error.message}</AlertTitle>
-											</Alert>
-										)}
-
-										<input type='hidden' name='_csrf' value={csrfToken} />
-										<input type='hidden' name='intent' value='update' />
-										<input type='hidden' name='projectId' value={loaderData.projectId} />
-
-										<Field>
-											<FieldLabel>Retention time</FieldLabel>
-
-											<Select name='days' defaultValue={loaderData.days.toString()}>
-												<SelectTrigger className='w-full'>
-													<SelectValue placeholder='Retention days' />
-												</SelectTrigger>
-
-												<SelectContent>
-													<SelectGroup>
-														<SelectLabel>Retention time</SelectLabel>
-														<SelectItem value='0'>{retentionDaysMap['0']}</SelectItem>
-														<SelectItem value='30'>{retentionDaysMap['30']}</SelectItem>
-														<SelectItem value='60'>{retentionDaysMap['60']}</SelectItem>
-														<SelectItem value='90'>{retentionDaysMap['90']}</SelectItem>
-														<SelectItem value='180'>{retentionDaysMap['180']}</SelectItem>
-														<SelectItem value='365'>{retentionDaysMap['365']}</SelectItem>
-													</SelectGroup>
-												</SelectContent>
-											</Select>
-										</Field>
-
-										<Field className='flex flex-row justify-end items-end'>
-											<Button type='submit' disabled={fetcher.state !== 'idle'} className='w-fit'>
-												<Check />
-												Save
-											</Button>
-										</Field>
-									</FieldGroup>
-								</fetcher.Form>
-							</CardContent>
-						</Card>
-					</div>
-				</Section>
-			</div>
-		</Page>
-	);
+	return redirect(`/projects/${projectId}/settings`);
 }

--- a/logwolf-server/frontend/app/routes.ts
+++ b/logwolf-server/frontend/app/routes.ts
@@ -15,5 +15,6 @@ export default [
 		route('settings', 'pages/settings/index.tsx'),
 		route('projects', 'pages/projects/index.tsx'),
 		route('projects/new', 'pages/projects/new/index.tsx'),
+		route('projects/:id/settings', 'pages/projects/settings/index.tsx'),
 	]),
 ] satisfies RouteConfig;

--- a/logwolf-server/frontend/docs/OVERVIEW.md
+++ b/logwolf-server/frontend/docs/OVERVIEW.md
@@ -34,7 +34,8 @@ app/
 │   ├── dashboard/        # Metrics overview + charts
 │   ├── events/           # Event list, detail view, create form
 │   ├── keys/             # API key management
-│   └── settings/         # System settings (retention TTL)
+│   ├── projects/         # Project list, create, switch, per-project settings
+│   └── settings/         # Redirect to the current project's settings
 ├── lib/
 │   ├── api.ts            # Dashboard API client (calls Broker internal routes)
 │   ├── logwolf.ts        # Logwolf SDK setup for client-side error tracking
@@ -55,19 +56,20 @@ app/
 
 ## Routes
 
-| Path               | Auth      | Description                   |
-| ------------------ | --------- | ----------------------------- |
-| `/`                | Public    | Landing page                  |
-| `/auth`            | Public    | GitHub OAuth login            |
-| `/dashboard`       | Protected | Metrics overview with charts  |
-| `/events`          | Protected | Paginated event list          |
-| `/events/create`   | Protected | Create a new event            |
-| `/events/:id`      | Protected | Event detail view             |
-| `/keys`            | Protected | API key management            |
-| `/settings`        | Protected | Retention and system settings |
-| `/projects`        | Protected | Projects the user belongs to  |
-| `/projects/new`    | Protected | Create a project              |
-| `/projects/switch` | Protected | POST-only project switch      |
+| Path                     | Auth      | Description                                 |
+| ------------------------ | --------- | ------------------------------------------- |
+| `/`                      | Public    | Landing page                                |
+| `/auth`                  | Public    | GitHub OAuth login                          |
+| `/dashboard`             | Protected | Metrics overview with charts                |
+| `/events`                | Protected | Paginated event list                        |
+| `/events/create`         | Protected | Create a new event                          |
+| `/events/:id`            | Protected | Event detail view                           |
+| `/keys`                  | Protected | API key management                          |
+| `/settings`              | Protected | Redirects to the current project's settings |
+| `/projects`              | Protected | Projects the user belongs to                |
+| `/projects/new`          | Protected | Create a project                            |
+| `/projects/switch`       | Protected | POST-only project switch                    |
+| `/projects/:id/settings` | Protected | Rename, retention, members, delete          |
 
 ## Project selection
 
@@ -80,6 +82,18 @@ without a current project.
 Switching projects is a POST to `/projects/switch`, which re-checks membership
 server-side before writing the session. The sidebar switcher and the `/projects`
 list both go through it.
+
+## Project settings
+
+`/projects/:id/settings` holds everything scoped to one project: its name, the
+retention window, the member list, and deletion. Both the loader and the action
+resolve the `:id` against the caller's own project list, so a project the user
+does not belong to sends them back to `/projects` instead of surfacing a 403.
+
+Every section except retention is owner-only — the broker enforces that as well,
+so the role checks in the route are there to keep a stale tab from producing a
+bare "forbidden". Deleting a project clears `currentProjectID` when it was the
+one in session and returns to `/projects`, where the layout takes over.
 
 ## Authentication
 


### PR DESCRIPTION
Closes #16.

Adds `/projects/:id/settings` with four sections — General (rename, read-only slug), Data retention, Members (add/remove by GitHub login), and Danger zone (delete behind a typed-name confirmation). `/settings` becomes a redirect to the current project's settings, and the sidebar links straight at the project so the item highlights.

Both the loader and the action resolve `:id` against the caller's own project list, so a project the user does not belong to redirects to `/projects` instead of surfacing a 403. Retention is editable by any member; renaming, member changes and deletion are owner-only — enforced in the broker and mirrored in the route so a stale tab gets a message instead of a bare "forbidden". The delete confirmation is re-checked server-side, and deleting clears `currentProjectID` before returning to `/projects`, where the layout forwards to `/projects/new` if nothing is left.

## Verification

`npm run typecheck`, `npm run lint` (0 errors), `npm run build` and `oxfmt --check` all pass.

Also ran the built SSR server against a stub broker with a forged session: all four sections render; each intent hits the right broker endpoint and revalidates the loader, so member changes appear without a page reload; rename preserves the slug; a wrong delete confirmation issues no DELETE; the correct one deletes, clears `currentProjectID` and 302s to `/projects`; a non-member id redirects to `/projects`; `/settings` forwards correctly; missing or wrong CSRF returns 403. With the stub reporting `role: member`, the page renders exactly as specified — name field disabled, danger zone hidden, no add form or remove buttons, retention still editable — and a rename attempt is rejected server-side.

Not verified against the real stack; that needs Docker plus a GitHub OAuth login.

## Noted, not fixed

`/dashboard` and `/keys` read the current project from a `?projectId` query param that nothing ever sets, so both are stuck on their empty state. Pre-existing from the previous phase and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)