### PR TITLE
feat(#17): project-scoped pages and dashboard event access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ docker compose up
 - SDK/API clients: Bearer tokens with `lw_` prefix, validated and cached with TTL + rate limiting (in broker middleware)
 - Dashboard: GitHub OAuth 2.0 (user/org allowlist via env vars), iron-session cookies + CSRF tokens on mutations
 
-**Reading vs. writing:** Broker handles writes asynchronously (via RabbitMQ) and reads synchronously (via RPC to logger). Do not add direct DB calls to broker or listener.
+**Reading vs. writing:** Broker handles writes asynchronously (via RabbitMQ) and reads synchronously (via RPC to logger). Do not add direct DB calls to broker or listener. This holds for both entry points: SDK clients scoped by API key, and the dashboard scoped by project id + membership.
 
 **RabbitMQ topology:** Topic exchange `logs_topic`; routing keys `log.INFO`, `log.WARNING`, `log.ERROR`. Queue declarations live in `toolbox/event/event.go`.
 
@@ -98,7 +98,7 @@ Entry point: `cmd/api/main.go`. Key files: `routes.go`, `handlers.go`, `middlewa
 
 - `POST /logs`, `POST /logs/batch` — enqueue events (async, 202)
 - `GET /logs`, `DELETE /logs` — proxy to Logger RPC
-- Internal routes (`X-Internal-Secret`): `/keys`, `/settings/retention`, `/metrics`
+- Internal routes (`X-Internal-Secret` + `X-User-Login`): `/keys`, `/settings/retention`, `/metrics`, `/projects/...` — including `/projects/{id}/logs`, the dashboard's project-scoped read/write path for events
 - `requireAPIKey` middleware caches key lookups; `requireInternalSecret` guards dashboard routes
 
 ### Listener (`logwolf-server/listener`)
@@ -113,6 +113,7 @@ RPC methods (Go stdlib `net/rpc`):
 
 - `RPCServer.LogInfo` — insert event
 - `RPCServer.GetLogs` — query with pagination/filtering
+- `RPCServer.GetLog` — fetch one event by id within a project
 - `RPCServer.DeleteLog` — delete by filter, returns count
 
 ### Toolbox (`logwolf-server/toolbox`)
@@ -138,7 +139,7 @@ Routes: `/` (public), `/auth`, `/dashboard`, `/events`, `/events/new`, `/events/
 
 The layout loader keeps `currentProjectID` in the session honest and redirects a user with no projects to `/projects/new`, the only protected page that renders without a current project.
 
-Pages take the current project from the session (`getCurrentProjectID`), never from the URL or a form field, so the redirect back from `/projects/switch` revalidates them into the new project. `/events` is the exception: it reads through the SDK, which authenticates with the dashboard's own `API_KEY` and therefore stays on that key's project.
+Pages take the current project from the session (`getCurrentProjectID`), never from the URL or a form field, so the redirect back from `/projects/switch` revalidates them into the new project. `/events` included: it goes through the broker's `/projects/:id/logs` routes, not the SDK. The SDK's key belongs to one fixed project, so `lib/logwolf.ts` is now only the dashboard's own error tracking.
 
 Project name, retention, members and deletion all live on `/projects/:id/settings`. Retention is editable by any member; renaming, member changes and deletion are owner-only, enforced in the broker and mirrored in the route so the UI can explain itself.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,13 +134,15 @@ Key files: `lib/client.ts` (Logwolf class), `lib/schema.ts` (Zod schemas), `lib/
 
 Key files: `app/root.tsx`, `app/lib/api.ts` (dashboard API client), `app/lib/auth.server.ts`.
 
-Routes: `/` (public), `/auth`, `/dashboard`, `/events`, `/events/create`, `/events/:id`, `/keys`, `/projects`, `/projects/new`, `/projects/switch`, `/projects/:id/settings`. `/settings` is a redirect to the current project's settings page.
+Routes: `/` (public), `/auth`, `/dashboard`, `/events`, `/events/new`, `/events/:id`, `/keys`, `/projects`, `/projects/new`, `/projects/switch`, `/projects/:id/settings`. `/settings` is a redirect to the current project's settings page.
 
 The layout loader keeps `currentProjectID` in the session honest and redirects a user with no projects to `/projects/new`, the only protected page that renders without a current project.
 
+Pages take the current project from the session (`getCurrentProjectID`), never from the URL or a form field, so the redirect back from `/projects/switch` revalidates them into the new project. `/events` is the exception: it reads through the SDK, which authenticates with the dashboard's own `API_KEY` and therefore stays on that key's project.
+
 Project name, retention, members and deletion all live on `/projects/:id/settings`. Retention is editable by any member; renaming, member changes and deletion are owner-only, enforced in the broker and mirrored in the route so the UI can explain itself.
 
-`lib/api.ts` → calls Broker internal routes via `X-Internal-Secret`. Never calls public SDK routes.
+`lib/api.ts` → calls Broker internal routes via `X-Internal-Secret`, plus `X-User-Login` from the session for the broker's membership checks; project-scoped methods take the project id as an argument. Never calls public SDK routes.
 
 The frontend instruments itself with `@logwolf/client-js` (`lib/logwolf.ts`) for error tracking.
 

--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -113,29 +114,10 @@ func (app *Config) GetLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	qp := r.URL.Query()
-	page, err := strconv.ParseInt(qp.Get("page"), 10, 0)
-	if err != nil {
-		page = 0
-	}
-
-	if page < 1 {
-		page = 1
-	}
-
-	pageSize, err := strconv.ParseInt(qp.Get("pageSize"), 10, 0)
-	if err != nil {
-		pageSize = 0
-	}
-
-	if pageSize < 1 {
-		pageSize = 20
-	}
-
 	var result []data.LogEntry
 	err = client.Call("RPCServer.GetLogs", data.QueryParams{
 		ProjectID:  projectIDFromContext(r),
-		Pagination: data.PaginationParams{Page: page, PageSize: pageSize},
+		Pagination: paginationFromQuery(r.URL.Query()),
 	}, &result)
 	if err != nil {
 		app.errorJSON(w, err)
@@ -147,6 +129,22 @@ func (app *Config) GetLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: result})
+}
+
+// paginationFromQuery reads page/pageSize off a query string, falling back to
+// the first page of 20 whenever either is missing or unusable.
+func paginationFromQuery(qp url.Values) data.PaginationParams {
+	page, err := strconv.ParseInt(qp.Get("page"), 10, 0)
+	if err != nil || page < 1 {
+		page = 1
+	}
+
+	pageSize, err := strconv.ParseInt(qp.Get("pageSize"), 10, 0)
+	if err != nil || pageSize < 1 {
+		pageSize = 20
+	}
+
+	return data.PaginationParams{Page: page, PageSize: pageSize}
 }
 
 func (app *Config) DeleteLog(w http.ResponseWriter, r *http.Request) {
@@ -819,4 +817,179 @@ func (app *Config) RemoveProjectMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "Member removed."})
+}
+
+// --- Project-scoped log access ---
+
+// The dashboard reads and writes events through the routes below instead of the
+// public SDK ones. It authenticates as a user rather than as an API key, so the
+// project cannot come from a key: it comes from the path, and the caller has to
+// be a member of it.
+
+// requireProjectAccess confirms the caller belongs to the project named in the
+// path, over the connection the handler already opened. It returns false once a
+// response has been written, so the handler only has to return — and the client
+// stays the handler's to close.
+func (app *Config) requireProjectAccess(w http.ResponseWriter, r *http.Request, client *rpc.Client, projectID string) bool {
+	isMember, err := checkProjectMembership(client, projectID, userLoginFromContext(r))
+	if err != nil {
+		app.errorJSON(w, err)
+		return false
+	}
+	if !isMember {
+		app.denyProjectAccess(w, client, projectID)
+		return false
+	}
+
+	return true
+}
+
+// logNotFound reports whether an RPC error means "this project has no such log".
+// net/rpc flattens errors into strings, so the cause has to be read back out of
+// the message. A malformed id is not found either — it cannot name a document.
+func logNotFound(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "no documents in result") || strings.Contains(msg, "not a valid ObjectID")
+}
+
+func (app *Config) ListProjectLogs(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "id")
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	if !app.requireProjectAccess(w, r, client, projectID) {
+		return
+	}
+
+	var result []data.LogEntry
+	err = client.Call("RPCServer.GetLogs", data.QueryParams{
+		ProjectID:  projectID,
+		Pagination: paginationFromQuery(r.URL.Query()),
+	}, &result)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	if result == nil {
+		result = []data.LogEntry{}
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: result})
+}
+
+func (app *Config) GetProjectLog(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "id")
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	if !app.requireProjectAccess(w, r, client, projectID) {
+		return
+	}
+
+	filter := data.RPCLogEntryFilter{ID: chi.URLParam(r, "logID"), ProjectID: projectID}
+
+	var entry data.LogEntry
+	if err := client.Call("RPCServer.GetLog", filter, &entry); err != nil {
+		if logNotFound(err) {
+			app.errorJSON(w, fmt.Errorf("log not found"), http.StatusNotFound)
+			return
+		}
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: entry})
+}
+
+func (app *Config) CreateProjectLog(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "id")
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	if !app.requireProjectAccess(w, r, client, projectID) {
+		return
+	}
+
+	var payload data.JSONLogPayload
+	if err := app.readJSON(w, r, &payload); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	// Whatever project the body named is discarded: the event belongs to the one
+	// in the path, which the caller was just checked against.
+	payload.ProjectID = projectID
+
+	evp := event.Payload{Action: "log", Log: payload}
+
+	emitter, err := event.NewEmitter(app.Rabbit)
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	j, err := json.MarshalIndent(&evp, "", "	")
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	if err := emitter.Push(string(j), "log.INFO"); err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+
+	app.writeJSON(w, http.StatusAccepted, jsonResponse{Error: false, Message: "OK!"})
+}
+
+func (app *Config) DeleteProjectLog(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "id")
+
+	client, err := rpc.Dial("tcp", loggerRPCAddr())
+	if err != nil {
+		app.errorJSON(w, err)
+		return
+	}
+	defer client.Close()
+
+	if !app.requireProjectAccess(w, r, client, projectID) {
+		return
+	}
+
+	filter := data.RPCLogEntryFilter{ID: chi.URLParam(r, "logID"), ProjectID: projectID}
+
+	var deleted int64
+	if err := client.Call("RPCServer.DeleteLog", filter, &deleted); err != nil {
+		if logNotFound(err) {
+			app.errorJSON(w, fmt.Errorf("log not found"), http.StatusNotFound)
+			return
+		}
+		app.errorJSON(w, err)
+		return
+	}
+
+	// A log of another project matches the filter no better than a deleted one,
+	// so both land here rather than reporting a successful delete of nothing.
+	if deleted == 0 {
+		app.errorJSON(w, fmt.Errorf("log not found"), http.StatusNotFound)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: fmt.Sprintf("Deleted entries: %d", deleted)})
 }

--- a/logwolf-server/broker/cmd/api/handlers.go
+++ b/logwolf-server/broker/cmd/api/handlers.go
@@ -203,6 +203,11 @@ func (app *Config) ListAPIKeys(w http.ResponseWriter, r *http.Request) {
 		app.errorJSON(w, err)
 		return
 	}
+
+	if keys == nil {
+		keys = []data.APIKey{}
+	}
+
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Message: "OK!", Data: keys})
 }
 

--- a/logwolf-server/broker/cmd/api/routes.go
+++ b/logwolf-server/broker/cmd/api/routes.go
@@ -42,6 +42,10 @@ func (app *Config) routes() http.Handler {
 		r.Get("/projects/{id}/members", app.ListProjectMembers)
 		r.Post("/projects/{id}/members", app.AddProjectMember)
 		r.Delete("/projects/{id}/members/{login}", app.RemoveProjectMember)
+		r.Get("/projects/{id}/logs", app.ListProjectLogs)
+		r.Post("/projects/{id}/logs", app.CreateProjectLog)
+		r.Get("/projects/{id}/logs/{logID}", app.GetProjectLog)
+		r.Delete("/projects/{id}/logs/{logID}", app.DeleteProjectLog)
 	})
 
 	// Protected routes

--- a/logwolf-server/broker/docs/OVERVIEW.md
+++ b/logwolf-server/broker/docs/OVERVIEW.md
@@ -48,9 +48,19 @@ cmd/api/
 | `GET`    | `/projects/{id}/members`         | List members                                |
 | `POST`   | `/projects/{id}/members`         | Add a member                                |
 | `DELETE` | `/projects/{id}/members/{login}` | Remove a member                             |
+| `GET`    | `/projects/{id}/logs`            | List a project's events (paginated)         |
+| `POST`   | `/projects/{id}/logs`            | Submit an event to a project (async, 202)   |
+| `GET`    | `/projects/{id}/logs/{logID}`    | Get one event                               |
+| `DELETE` | `/projects/{id}/logs/{logID}`    | Delete one event                            |
 
 Internal routes also require `X-User-Login`; project access is checked against
 that login on every call.
+
+The `/projects/{id}/logs` routes are the dashboard's way into events. They do the
+same work as the public `/logs` routes, but take the project from the path and
+check the caller's membership instead of reading it off an API key — the
+dashboard authenticates as a user and has no key of its own to scope it. An id
+that belongs to another project is a 404, never another project's event.
 
 ### Health
 
@@ -76,7 +86,8 @@ Events are published to the `logs_topic` exchange with routing key `log.<SEVERIT
 ## Read path
 
 ```
-Client → GET /logs → requireAPIKey → RPC call to Logger:5001 → response
+Client    → GET /logs                   → requireAPIKey       → RPC call to Logger:5001 → response
+Dashboard → GET /projects/{id}/logs     → membership check    → RPC call to Logger:5001 → response
 ```
 
 ## Environment variables

--- a/logwolf-server/frontend/app/lib/api.ts
+++ b/logwolf-server/frontend/app/lib/api.ts
@@ -1,4 +1,18 @@
+import {
+	LogwolfEventSchema,
+	type CreateLogwolfEventDTOSchema,
+	type LogwolfEventData,
+	type Pagination,
+} from '@logwolf/client-js';
+import z from 'zod';
+
 type ApiResponse<T> = { message: string } & ({ error: true; data: never } | { error: false; data: T });
+
+/**
+ * An event the way the broker takes it in: `data` already encoded as a JSON
+ * string. `LogwolfEvent.toObject()` produces exactly this shape.
+ */
+export type EncodedEvent = z.input<typeof CreateLogwolfEventDTOSchema>;
 
 type ApiKey = {
 	id: string;
@@ -56,6 +70,10 @@ export interface IApi {
 	getRetention(projectId: string): Promise<{ days: RetentionDays }>;
 	updateRetention(projectId: string, days: number): Promise<{ days: RetentionDays }>;
 	getMetrics(projectId: string): Promise<Metrics>;
+	getLogs(projectId: string, p: Pagination): Promise<LogwolfEventData[]>;
+	getLog(projectId: string, id: string): Promise<LogwolfEventData>;
+	createLog(projectId: string, event: EncodedEvent): Promise<void>;
+	deleteLog(projectId: string, id: string): Promise<void>;
 }
 
 export class Api implements IApi {
@@ -168,7 +186,11 @@ export class Api implements IApi {
 			headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
 			body: JSON.stringify({ project_id: projectId }),
 		});
-		const json = (await res.json()) as ApiResponse<{ key: string; prefix: string; id: string }>;
+		const json = (await res.json()) as ApiResponse<{
+			key: string;
+			prefix: string;
+			id: string;
+		}>;
 		if (json.error) throw new Error(json.message);
 
 		return json.data;
@@ -220,6 +242,50 @@ export class Api implements IApi {
 		if (json.error) throw new Error(json.message);
 
 		return json.data;
+	}
+
+	public async getLogs(projectId: string, p: Pagination): Promise<LogwolfEventData[]> {
+		const url = new URL(`${this.baseUrl}projects/${projectId}/logs`);
+		url.searchParams.set('page', String(p.page));
+		url.searchParams.set('pageSize', String(p.pageSize));
+		const res = await fetch(url.toString(), {
+			method: 'GET',
+			headers: this.internalHeaders(),
+		});
+		const json = (await res.json()) as ApiResponse<unknown[]>;
+		if (json.error) throw new Error(json.message);
+
+		return LogwolfEventSchema.array().parse(json.data ?? []);
+	}
+
+	public async getLog(projectId: string, id: string): Promise<LogwolfEventData> {
+		const res = await fetch(`${this.baseUrl}projects/${projectId}/logs/${encodeURIComponent(id)}`, {
+			method: 'GET',
+			headers: this.internalHeaders(),
+		});
+		const json = (await res.json()) as ApiResponse<unknown>;
+		if (json.error) throw new Error(json.message);
+
+		return LogwolfEventSchema.parse(json.data);
+	}
+
+	public async createLog(projectId: string, event: EncodedEvent): Promise<void> {
+		const res = await fetch(`${this.baseUrl}projects/${projectId}/logs`, {
+			method: 'POST',
+			headers: this.internalHeaders({ 'Content-Type': 'application/json' }),
+			body: JSON.stringify(event),
+		});
+		const json = (await res.json()) as ApiResponse<void>;
+		if (json.error) throw new Error(json.message);
+	}
+
+	public async deleteLog(projectId: string, id: string): Promise<void> {
+		const res = await fetch(`${this.baseUrl}projects/${projectId}/logs/${encodeURIComponent(id)}`, {
+			method: 'DELETE',
+			headers: this.internalHeaders(),
+		});
+		const json = (await res.json()) as ApiResponse<void>;
+		if (json.error) throw new Error(json.message);
 	}
 }
 

--- a/logwolf-server/frontend/app/lib/api.ts
+++ b/logwolf-server/frontend/app/lib/api.ts
@@ -53,7 +53,7 @@ export type Metrics = {
 	avg_duration_ms: number;
 	events_last_24h: number;
 	errors_last_24h: number;
-	top_tags: { tag: string; count: number }[];
+	top_tags: { tag: string; count: number }[] | null;
 };
 
 export interface IApi {

--- a/logwolf-server/frontend/app/pages/dashboard/components/tags-bar-chart.tsx
+++ b/logwolf-server/frontend/app/pages/dashboard/components/tags-bar-chart.tsx
@@ -11,7 +11,7 @@ const maxBarAmt = 5;
 type Props = React.ComponentProps<typeof Card> & { p: Promise<Metrics> };
 export function TagsBarChart({ className, p, ...props }: Props) {
 	const metrics = use(p);
-	const data = metrics.top_tags.toSorted((a, b) => b.count - a.count).slice(0, maxBarAmt);
+	const data = metrics.top_tags?.toSorted((a, b) => b.count - a.count).slice(0, maxBarAmt);
 
 	return (
 		<Card className={cn('shadow-none h-full', className)} {...props}>

--- a/logwolf-server/frontend/app/pages/dashboard/index.tsx
+++ b/logwolf-server/frontend/app/pages/dashboard/index.tsx
@@ -7,6 +7,7 @@ import { Section } from '~/components/ui/section';
 import { eventContext } from '~/context';
 import { createApi } from '~/lib/api';
 import { requireAuth } from '~/lib/auth.server';
+import { getCurrentProjectID } from '~/lib/session.server';
 
 import type { Route } from './+types';
 import { AverageDuration, AverageDurationSkeleton } from './components/average-duration';
@@ -25,17 +26,15 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 	event?.addTag('loader');
 
 	const user = await requireAuth(request);
-	const projectId = new URL(request.url).searchParams.get('projectId') ?? '';
 
-	if (!projectId) {
-		return { metrics: null, noProject: true };
-	}
+	const projectId = await getCurrentProjectID(request);
+	if (!projectId) return { metrics: null };
 
 	const api = createApi(user.login);
 	const metrics = api.getMetrics(projectId);
 	event?.set('loaderData', 'async data');
 
-	return { metrics, noProject: false };
+	return { metrics };
 }
 
 export default function Dashboard({ loaderData }: Route.ComponentProps) {

--- a/logwolf-server/frontend/app/pages/events/create/index.tsx
+++ b/logwolf-server/frontend/app/pages/events/create/index.tsx
@@ -24,9 +24,11 @@ import { Spinner } from '~/components/ui/spinner';
 import { Textarea } from '~/components/ui/textarea';
 import { eventContext } from '~/context';
 import { useCsrfToken } from '~/hooks/use-csrf-token';
+import { createApi } from '~/lib/api';
+import { requireAuth } from '~/lib/auth.server';
 import { validateCsrfToken } from '~/lib/csrf.server';
 import { formatSeverity, severityMap } from '~/lib/format';
-import { logwolf } from '~/lib/logwolf';
+import { getCurrentProjectID } from '~/lib/session.server';
 
 import type { Route } from './+types';
 import { Preview } from './components/preview';
@@ -51,12 +53,20 @@ export async function action({ request, context }: Route.ActionArgs) {
 	event?.addTag('action');
 
 	try {
+		const user = await requireAuth(request);
 		const fd = await request.formData();
 
 		await validateCsrfToken(request, fd);
 
+		// The event lands in the project the session is pointed at — the form has
+		// no say in it, and neither does the dashboard's own API key.
+		const projectId = await getCurrentProjectID(request);
+		if (!projectId) return redirect('/projects/new');
+
 		const d = FormDataSchema.decode(Object.fromEntries(fd.entries()) as CreateEventFormData);
-		const res = await logwolf.create(new LogwolfEvent(d)).then(() => redirect('/events'));
+		const res = await createApi(user.login)
+			.createLog(projectId, new LogwolfEvent(d).toObject())
+			.then(() => redirect('/events'));
 		event?.set('actionData', res);
 
 		return res;

--- a/logwolf-server/frontend/app/pages/events/details/index.tsx
+++ b/logwolf-server/frontend/app/pages/events/details/index.tsx
@@ -7,7 +7,9 @@ import { JSONBlock } from '~/components/ui/json-block';
 import { Section } from '~/components/ui/section';
 import { SeverityBadge } from '~/components/ui/severity-badge';
 import { eventContext } from '~/context';
-import { logwolf } from '~/lib/logwolf';
+import { createApi } from '~/lib/api';
+import { requireAuth } from '~/lib/auth.server';
+import { getCurrentProjectID } from '~/lib/session.server';
 
 import type { Route } from './+types';
 import { InfoItem } from './components/info-item';
@@ -16,18 +18,25 @@ export function meta({ loaderData }: Route.MetaArgs) {
 	return [{ title: loaderData.name + ' - Logwolf' }, { name: 'description', content: 'Logwolf event details!' }];
 }
 
-export async function loader({ params, context }: Route.LoaderArgs) {
+export async function loader({ request, params, context }: Route.LoaderArgs) {
 	const event = context.get(eventContext);
 	event?.addTag('loader');
 
-	// A rejected SDK key reads the same as a missing event here: there is nothing
-	// to show, so fall back to the list rather than a 500.
-	const log = await logwolf.getOne(params.id).catch((err: unknown) => {
-		event?.setSeverity('error');
-		event?.set('loaderError', err);
+	const user = await requireAuth(request);
 
-		return null;
-	});
+	const projectId = await getCurrentProjectID(request);
+	if (!projectId) throw redirect('/projects/new');
+
+	// An event of another project is a 404 here, and a 404 reads the same as any
+	// other failure: there is nothing to show, so fall back to the list.
+	const log = await createApi(user.login)
+		.getLog(projectId, params.id)
+		.catch((err: unknown) => {
+			event?.setSeverity('error');
+			event?.set('loaderError', err);
+
+			return null;
+		});
 	if (!log) throw redirect('/events');
 
 	event?.set('loaderData', ['too much data']);

--- a/logwolf-server/frontend/app/pages/events/index.tsx
+++ b/logwolf-server/frontend/app/pages/events/index.tsx
@@ -1,4 +1,3 @@
-import { type DeleteLogwolfEventDTO } from '@logwolf/client-js';
 import { Plus } from 'lucide-react';
 import { Link } from 'react-router';
 
@@ -8,8 +7,9 @@ import { Button } from '~/components/ui/button';
 import { Section } from '~/components/ui/section';
 import { eventContext } from '~/context';
 import { useCsrfToken } from '~/hooks/use-csrf-token';
+import { createApi } from '~/lib/api';
+import { requireAuth } from '~/lib/auth.server';
 import { validateCsrfToken } from '~/lib/csrf.server';
-import { logwolf } from '~/lib/logwolf';
 import { getCurrentProjectID } from '~/lib/session.server';
 
 import type { Route } from './+types';
@@ -23,14 +23,15 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 	const event = context.get(eventContext);
 	event?.addTag('loader');
 
+	const user = await requireAuth(request);
+
 	const projectId = await getCurrentProjectID(request);
 	if (!projectId) return { events: [], noProject: true, error: null };
 
-	// Events are still read through the SDK route, which authenticates with its
-	// own API key instead of the dashboard session. A rejected key must not take
-	// the whole page down, so it surfaces as an alert above an empty table.
+	// A broker that refuses the read must not take the whole page down, so it
+	// surfaces as an alert above an empty table.
 	try {
-		const events = await logwolf.getAll({ page: 1, pageSize: 20 });
+		const events = await createApi(user.login).getLogs(projectId, { page: 1, pageSize: 20 });
 		event?.set('loaderData', ['too much data']);
 
 		return { events, noProject: false, error: null };
@@ -47,17 +48,23 @@ export async function action({ request, context }: Route.ActionArgs) {
 	event?.addTag('action');
 
 	if (request.method === 'DELETE') {
+		const user = await requireAuth(request);
 		const fd = await request.formData();
 
 		await validateCsrfToken(request, fd);
 
-		const data = Object.fromEntries(fd.entries()) as DeleteLogwolfEventDTO;
+		// Deleting is scoped to the project in session, so an id belonging to
+		// another one is a 404 rather than someone else's event disappearing.
+		const projectId = await getCurrentProjectID(request);
+		if (!projectId) return { error: 'No project selected.' };
+
+		const id = fd.get('id')?.toString() ?? '';
 
 		try {
-			const res = await logwolf.delete(data);
-			event?.set('actionData', res);
+			await createApi(user.login).deleteLog(projectId, id);
+			event?.set('actionData', { deleted: id });
 
-			return res;
+			return { deleted: id };
 		} catch (err) {
 			event?.setSeverity('error');
 			event?.set('actionError', err);

--- a/logwolf-server/frontend/app/pages/keys/index.tsx
+++ b/logwolf-server/frontend/app/pages/keys/index.tsx
@@ -10,6 +10,7 @@ import { useCsrfToken } from '~/hooks/use-csrf-token';
 import { createApi } from '~/lib/api';
 import { requireAuth } from '~/lib/auth.server';
 import { validateCsrfToken } from '~/lib/csrf.server';
+import { getCurrentProjectID } from '~/lib/session.server';
 
 import type { Route } from './+types';
 
@@ -18,17 +19,17 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 	event?.addTag('loader');
 
 	const user = await requireAuth(request);
-	const projectId = new URL(request.url).searchParams.get('projectId') ?? '';
 
-	if (!projectId) {
-		return { keys: [], projectId: '', noProject: true };
-	}
+	// Keys are listed for the project the session is pointed at; switching
+	// projects revalidates this loader into that project's keys instead.
+	const projectId = await getCurrentProjectID(request);
+	if (!projectId) return { keys: [], noProject: true };
 
 	const api = createApi(user.login);
 	const res = await api.getKeys(projectId);
 	event?.set('loaderData', res);
 
-	return { keys: res, projectId, noProject: false };
+	return { keys: res, noProject: false };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -47,7 +48,12 @@ export async function action({ request, context }: Route.ActionArgs) {
 		const api = createApi(user.login);
 
 		if (intent === 'create') {
-			const projectId = fd.get('projectId')?.toString() ?? '';
+			// The new key belongs to the project in session rather than one named by
+			// the form, so a tab left open on a since-switched project cannot mint a
+			// key somewhere the user is no longer looking.
+			const projectId = await getCurrentProjectID(request);
+			if (!projectId) return { error: new Error('No project selected.') };
+
 			const res = await api.createKey(projectId);
 			event?.set('actionData', { ...res, key: '-' });
 			return { data: res };
@@ -112,7 +118,6 @@ export default function Keys({ loaderData }: Route.ComponentProps) {
 						<fetcher.Form method='post'>
 							<input type='hidden' name='_csrf' value={csrfToken} />
 							<input type='hidden' name='intent' value='create' />
-							<input type='hidden' name='projectId' value={loaderData.projectId} />
 							<Button type='submit' disabled={fetcher.state !== 'idle'}>
 								Generate new key
 							</Button>

--- a/logwolf-server/frontend/docs/OVERVIEW.md
+++ b/logwolf-server/frontend/docs/OVERVIEW.md
@@ -62,7 +62,7 @@ app/
 | `/auth`                  | Public    | GitHub OAuth login                          |
 | `/dashboard`             | Protected | Metrics overview with charts                |
 | `/events`                | Protected | Paginated event list                        |
-| `/events/create`         | Protected | Create a new event                          |
+| `/events/new`            | Protected | Create a new event                          |
 | `/events/:id`            | Protected | Event detail view                           |
 | `/keys`                  | Protected | API key management                          |
 | `/settings`              | Protected | Redirects to the current project's settings |
@@ -82,6 +82,13 @@ without a current project.
 Switching projects is a POST to `/projects/switch`, which re-checks membership
 server-side before writing the session. The sidebar switcher and the `/projects`
 list both go through it.
+
+Pages take the project from the session and nowhere else — never from the URL or
+a hidden form field. `/dashboard` and `/keys` call `getCurrentProjectID()` in
+their loaders and actions, so the redirect back from `/projects/switch`
+revalidates them straight into the new project. `/events` is the one exception:
+it still reads through the SDK route, which authenticates with its own API key
+rather than the dashboard session.
 
 ## Project settings
 
@@ -107,6 +114,8 @@ CSRF tokens are required on all mutating form submissions.
 ## API communication
 
 `lib/api.ts` exports an `Api` class that calls Broker's **internal routes** using the `X-Internal-Secret` header (sourced from `INTERNAL_API_SECRET`). The frontend never calls the public Broker routes — those are for SDK clients only.
+
+The client is request-scoped: `createApi(login)` takes the GitHub login of the signed-in user and sends it as `X-User-Login` on every call, which is what the broker checks project membership against. Project-scoped methods (`getKeys`, `createKey`, `getMetrics`, `getRetention`, `updateRetention`, and everything under `projects`) take the project id as an argument, so a route has to state which project it means.
 
 ## Error tracking
 

--- a/logwolf-server/frontend/docs/OVERVIEW.md
+++ b/logwolf-server/frontend/docs/OVERVIEW.md
@@ -84,11 +84,15 @@ server-side before writing the session. The sidebar switcher and the `/projects`
 list both go through it.
 
 Pages take the project from the session and nowhere else — never from the URL or
-a hidden form field. `/dashboard` and `/keys` call `getCurrentProjectID()` in
-their loaders and actions, so the redirect back from `/projects/switch`
-revalidates them straight into the new project. `/events` is the one exception:
-it still reads through the SDK route, which authenticates with its own API key
-rather than the dashboard session.
+a hidden form field. Every loader and action calls `getCurrentProjectID()` and
+passes the result to the API client, so the redirect back from
+`/projects/switch` revalidates them straight into the new project.
+
+That includes `/events`, which reads and writes through the broker's
+`/projects/:id/logs` routes rather than the SDK. The SDK authenticates with the
+dashboard's own `API_KEY`, which belongs to one fixed project — it could never
+follow the switcher, and it would have shown every user that project's events.
+`lib/logwolf.ts` keeps using it for what it is: the dashboard's own telemetry.
 
 ## Project settings
 
@@ -115,7 +119,9 @@ CSRF tokens are required on all mutating form submissions.
 
 `lib/api.ts` exports an `Api` class that calls Broker's **internal routes** using the `X-Internal-Secret` header (sourced from `INTERNAL_API_SECRET`). The frontend never calls the public Broker routes — those are for SDK clients only.
 
-The client is request-scoped: `createApi(login)` takes the GitHub login of the signed-in user and sends it as `X-User-Login` on every call, which is what the broker checks project membership against. Project-scoped methods (`getKeys`, `createKey`, `getMetrics`, `getRetention`, `updateRetention`, and everything under `projects`) take the project id as an argument, so a route has to state which project it means.
+The client is request-scoped: `createApi(login)` takes the GitHub login of the signed-in user and sends it as `X-User-Login` on every call, which is what the broker checks project membership against. Project-scoped methods (`getKeys`, `createKey`, `getMetrics`, `getRetention`, `updateRetention`, `getLogs`, `getLog`, `createLog`, `deleteLog`, and everything under `projects`) take the project id as an argument, so a route has to state which project it means.
+
+Event payloads come back exactly as the broker stores them, so `getLogs`/`getLog` decode them with the SDK's own `LogwolfEventSchema` — `data` back into an object, timestamps back into `Date`s. Pages therefore keep working with `LogwolfEventData`, unchanged by the move off the SDK transport.
 
 ## Error tracking
 

--- a/logwolf-server/logger/cmd/api/rpc.go
+++ b/logwolf-server/logger/cmd/api/rpc.go
@@ -49,6 +49,22 @@ func (r *RPCServer) GetLogs(p data.QueryParams, resp *[]data.LogEntry) error {
 	return nil
 }
 
+// GetLog fetches a single entry by id. The project is part of the query rather
+// than a check layered on top of it, so an id belonging to another project
+// comes back as "no documents in result" — the same as one that never existed.
+func (r *RPCServer) GetLog(f data.RPCLogEntryFilter, resp *data.LogEntry) error {
+	log.Printf("Getting log %s of project %s...\n", f.ID, f.ProjectID)
+
+	entry, err := r.models.GetLog(f.ID, f.ProjectID)
+	if err != nil {
+		log.Println("Error getting log:", err)
+		return err
+	}
+
+	*resp = *entry
+	return nil
+}
+
 func (r *RPCServer) DeleteLog(f data.RPCLogEntryFilter, resp *int64) error {
 	log.Printf("Deleting log %+v...\n", f)
 

--- a/logwolf-server/logger/docs/OVERVIEW.md
+++ b/logwolf-server/logger/docs/OVERVIEW.md
@@ -24,6 +24,7 @@ The RPC server is exposed via Go's standard `net/rpc` package on TCP port 5001.
 | --------------------- | ------------------- | ------------ | -------------------------------------------------- |
 | `RPCServer.LogInfo`   | `RPCLogPayload`     | `string`     | Insert a single log entry into MongoDB             |
 | `RPCServer.GetLogs`   | `QueryParams`       | `[]LogEntry` | Query logs with optional filtering and pagination  |
+| `RPCServer.GetLog`    | `RPCLogEntryFilter` | `LogEntry`   | Fetch one entry by id within a project             |
 | `RPCServer.DeleteLog` | `RPCLogEntryFilter` | `int64`      | Delete matching log entries; returns count deleted |
 
 ## HTTP interface


### PR DESCRIPTION
Closes #17.

`/dashboard` and `/keys` read the current project from a `?projectId` query param that nothing ever set — the gap noted at the end of #33 — so both were stuck on their empty state. They now take it from the session via `getCurrentProjectID()`, and so does the key-create action: a key can no longer be minted for whatever project a stale tab named in a hidden form field. The rest of the issue (the `X-User-Login` client, per-method project ids, the `'default'` hardcode, `/settings` as a redirect) had already landed with #32/#33.

That left `/events`, which the issue scoped out. It read through the SDK, whose key belongs to one fixed project, so it showed that project's events to every dashboard user regardless of the switcher — and wrote new ones into it. Closing that meant giving the dashboard a way in that isn't an API key:

- **logger** — `RPCServer.GetLog`, one entry by id within a project. `models.GetLog` was already project-scoped; nothing exposed it over RPC.
- **broker** — internal, membership-checked `/projects/{id}/logs` routes: list, submit, get one, delete one. The project comes from the path and never from the body, and an id belonging to another project is a 404, not someone else's event. Pagination parsing is now shared with the public `GET /logs`.
- **frontend** — `getLogs` / `getLog` / `createLog` / `deleteLog` on the API client, decoding responses with the SDK's own `LogwolfEventSchema` so pages keep receiving `LogwolfEventData` and no component changed. `lib/logwolf.ts` stays for what it actually is: the dashboard's own error tracking.

Also fixes `/keys` crashing on a project with no keys yet. `ListAPIKeysByProject` returns a nil slice, which reaches the browser as `"data": null`, and the page iterated it — invisible until the loader started actually fetching. `getKeys` now falls back to `[]`, as `getMembers` already did.

Docs updated across `CLAUDE.md` and the broker, logger and frontend overviews. The frontend route table's `/events/create` is corrected to `/events/new`, which is what `routes.ts` registers.

## Verification

`go build`, `go vet` and `go test` (broker + toolbox) pass; frontend `typecheck`, `lint` (0 errors) and `build` pass.

Not verified against the real stack — that needs Docker plus a GitHub OAuth login. The cross-project isolation assertions that would prove it end to end belong to #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
