### PR TITLE
feat(#18): orphan events migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
         working-directory: logwolf-server/toolbox
         run: go test ./... -v -count=1
 
+      - name: Run logger unit tests
+        working-directory: logwolf-server/logger
+        run: go test ./cmd/api/... -v -count=1
+
+      - name: Run listener unit tests
+        working-directory: logwolf-server/listener
+        run: go test ./cmd/api/... -v -count=1
+
   test-integration:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,9 @@ docker compose up
 
 **RabbitMQ topology:** Topic exchange `logs_topic`; routing keys `log.INFO`, `log.WARNING`, `log.ERROR`. Queue declarations live in `toolbox/event/event.go`.
 
-**Data retention:** Logger maintains a MongoDB TTL index on `logs.created_at`. Default is 90 days; supported values are 30/60/90/180/365. Changing the setting recreates the index.
+**Data retention:** Retention is per project (default 90 days; supported values are 30/60/90/180/365, or 0 for forever). A cleanup loop in Logger deletes expired logs project by project every `CLEANUP_INTERVAL`. The global TTL index used before multi-tenancy is dropped on startup.
+
+**Startup migration:** Logger adopts pre-multi-tenancy `logs`, `api_keys`, and `settings` (documents with no `project_id`) into a project named `Default` before it serves traffic, making every login in `LOGWOLF_ALLOWED_GITHUB_USERS` an owner. It is idempotent and silent when there is nothing to migrate. See `toolbox/data/migrate.go` and `logger/cmd/api/migrate.go`.
 
 ## Service details
 
@@ -107,7 +109,7 @@ Entry point: `cmd/api/main.go`. No external dependencies beyond toolbox. Pure co
 
 ### Logger (`logwolf-server/logger`)
 
-Entry point: `cmd/api/main.go`. Key files: `rpc.go`, `routes.go`.
+Entry point: `cmd/api/main.go`. Key files: `rpc.go`, `routes.go`, `migrate.go`, `cleanup.go`.
 
 RPC methods (Go stdlib `net/rpc`):
 
@@ -163,17 +165,18 @@ Copy `.env.example` to `.env` and fill in GitHub OAuth credentials before runnin
 
 Per-service env vars:
 
-| Variable              | Service          | Default                       | Description                              |
-| --------------------- | ---------------- | ----------------------------- | ---------------------------------------- |
-| `MONGO_URL`           | broker, logger   | `mongodb://mongo:27017`       | MongoDB connection                       |
-| `RABBITMQ_URL`        | broker, listener | `amqp://guest:guest@rabbitmq` | RabbitMQ connection                      |
-| `BROKER_PORT`         | broker           | `80`                          | HTTP listen port                         |
-| `LOGGER_RPC_PORT`     | logger           | `5001`                        | RPC listen port                          |
-| `LOGGER_HTTP_PORT`    | logger           | `80`                          | HTTP health check port                   |
-| `CLEANUP_INTERVAL`    | logger           | `1h`                          | Per-project retention cleanup frequency  |
-| `API_URL`             | frontend         | —                             | Broker base URL                          |
-| `INTERNAL_API_SECRET` | frontend         | —                             | Shared secret for internal Broker routes |
-| `SESSION_SECRET`      | frontend         | —                             | iron-session signing key                 |
+| Variable                       | Service          | Default                       | Description                                                            |
+| ------------------------------ | ---------------- | ----------------------------- | ---------------------------------------------------------------------- |
+| `MONGO_URL`                    | broker, logger   | `mongodb://mongo:27017`       | MongoDB connection                                                     |
+| `RABBITMQ_URL`                 | broker, listener | `amqp://guest:guest@rabbitmq` | RabbitMQ connection                                                    |
+| `BROKER_PORT`                  | broker           | `80`                          | HTTP listen port                                                       |
+| `LOGGER_RPC_PORT`              | logger           | `5001`                        | RPC listen port                                                        |
+| `LOGGER_HTTP_PORT`             | logger           | `80`                          | HTTP health check port                                                 |
+| `CLEANUP_INTERVAL`             | logger           | `1h`                          | Per-project retention cleanup frequency                                |
+| `LOGWOLF_ALLOWED_GITHUB_USERS` | frontend, logger | —                             | Dashboard allowlist; also the owners of the migrated `Default` project |
+| `API_URL`                      | frontend         | —                             | Broker base URL                                                        |
+| `INTERNAL_API_SECRET`          | frontend         | —                             | Shared secret for internal Broker routes                               |
+| `SESSION_SECRET`               | frontend         | —                             | iron-session signing key                                               |
 
 ## Detailed docs
 

--- a/logwolf-server/.env.example
+++ b/logwolf-server/.env.example
@@ -5,6 +5,8 @@ GITHUB_CLIENT_SECRET=
 
 # Restrict dashboard access — at least one of these must be set
 # Comma-separated list of GitHub usernames
+# On upgrade from a pre-multi-tenancy build, these users also become owners of
+# the Default project the logger creates for the existing data.
 LOGWOLF_ALLOWED_GITHUB_USERS=
 # Comma-separated list of GitHub org names (any member is allowed)
 LOGWOLF_ALLOWED_GITHUB_ORGS=

--- a/logwolf-server/docker-compose.yml
+++ b/logwolf-server/docker-compose.yml
@@ -44,6 +44,11 @@ services:
     deploy:
       mode: replicated
       replicas: 1
+    environment:
+      # Owners of the Default project created by the startup migration when an
+      # existing deployment is upgraded from a pre-multi-tenancy build.
+      LOGWOLF_ALLOWED_GITHUB_USERS: ${LOGWOLF_ALLOWED_GITHUB_USERS:-}
+      CLEANUP_INTERVAL: ${CLEANUP_INTERVAL:-1h}
     networks:
       - internal
 

--- a/logwolf-server/integration/helpers_test.go
+++ b/logwolf-server/integration/helpers_test.go
@@ -9,6 +9,10 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -102,10 +106,62 @@ func testAPIKey(t *testing.T, mongoURI string) string {
 
 // --- internal helpers ---
 
+// TestMain deletes the binaries built for the run once every test has finished.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if binDir != "" {
+		os.RemoveAll(binDir)
+	}
+	os.Exit(code)
+}
+
+var (
+	binMu   sync.Mutex
+	binDir  string
+	binPath = map[string]string{}
+)
+
+// serviceBinary compiles a service package once per run and returns the path to
+// the binary. Tests execute that binary directly rather than going through
+// `go run`, which is what makes cleanup reliable: `go run` starts the service as
+// a child of its own, so killing `go run` leaves the service running. On Windows
+// it survives the whole session, and a stray Listener that reconnects to a
+// recycled RabbitMQ port will consume the messages a later test is waiting for.
+func serviceBinary(t *testing.T, pkgPath string) string {
+	t.Helper()
+
+	binMu.Lock()
+	defer binMu.Unlock()
+
+	if path, ok := binPath[pkgPath]; ok {
+		return path
+	}
+
+	if binDir == "" {
+		dir, err := os.MkdirTemp("", "logwolf-integration")
+		if err != nil {
+			t.Fatalf("serviceBinary: temp dir: %v", err)
+		}
+		binDir = dir
+	}
+
+	out := filepath.Join(binDir, strings.NewReplacer("../", "", "/", "-").Replace(pkgPath))
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+
+	if output, err := exec.Command("go", "build", "-o", out, pkgPath).CombinedOutput(); err != nil {
+		t.Fatalf("serviceBinary %s: build failed: %v: %s", pkgPath, err, output)
+	}
+
+	binPath[pkgPath] = out
+	return out
+}
+
 func startProcess(t *testing.T, pkgPath string, env map[string]string) {
 	t.Helper()
 
-	cmd := exec.Command("go", "run", pkgPath)
+	cmd := exec.Command(serviceBinary(t, pkgPath))
 	cmd.Env = append(os.Environ(), envSlice(env)...)
 	// Leave Stdout and Stderr nil — os/exec will use os.DevNull directly,
 	// no pipes created, nothing to drain, cmd.Wait() returns immediately.

--- a/logwolf-server/integration/startup_migration_test.go
+++ b/logwolf-server/integration/startup_migration_test.go
@@ -1,0 +1,313 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/rabbitmq"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"golang.org/x/crypto/bcrypt"
+	"logwolf-toolbox/data"
+)
+
+// TestStartupMigration seeds a database in the shape a pre-multi-tenancy build
+// left behind — logs, an API key, and a retention setting with no project_id,
+// plus the old global TTL index — then boots the real Logger against it.
+//
+// Everything is asserted after the RPC port opens, which is the guarantee that
+// matters: the migration finishes before any caller can read.
+func TestStartupMigration(t *testing.T) {
+	ctx := context.Background()
+	mongoURI, client := startMongo(t)
+	db := client.Database("logs")
+
+	// --- Seed pre-multi-tenancy data ---
+
+	legacyLogs := []interface{}{
+		bson.M{"name": "old-event-1", "data": "{}", "severity": "INFO", "tags": []string{"legacy"}, "created_at": time.Now().Add(-48 * time.Hour), "updated_at": time.Now()},
+		bson.M{"name": "old-event-2", "data": "{}", "severity": "ERROR", "tags": []string{"legacy"}, "created_at": time.Now().Add(-24 * time.Hour), "updated_at": time.Now()},
+		// project_id present but empty — a half-written document from an in-between build.
+		bson.M{"name": "old-event-3", "data": "{}", "severity": "WARNING", "project_id": "", "created_at": time.Now(), "updated_at": time.Now()},
+	}
+	if _, err := db.Collection("logs").InsertMany(ctx, legacyLogs); err != nil {
+		t.Fatalf("seed logs: %v", err)
+	}
+
+	if _, err := db.Collection("api_keys").InsertOne(ctx, bson.M{
+		"prefix": "lw_legacy1", "hash": "$2a$10$notarealhash", "active": true, "created_at": time.Now(),
+	}); err != nil {
+		t.Fatalf("seed api_keys: %v", err)
+	}
+
+	if _, err := db.Collection("settings").InsertOne(ctx, bson.M{
+		"key": "retention_days", "value": 30,
+	}); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	// The global TTL index the old build maintained on logs.created_at.
+	if _, err := db.Collection("logs").Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "created_at", Value: 1}},
+		Options: options.Index().SetExpireAfterSeconds(30 * 24 * 60 * 60).SetName("ttl_created_at"),
+	}); err != nil {
+		t.Fatalf("seed TTL index: %v", err)
+	}
+
+	// --- First boot: the migration runs ---
+
+	startLogger(t, mongoURI, "alice,Bob")
+
+	project := requireDefaultProject(t, db)
+	projectID := project.ID.Hex()
+
+	// All three logs are readable in the Default project, including the one that
+	// carried an empty project_id.
+	assertCount(t, db, "logs", bson.M{"project_id": projectID}, 3)
+	assertCount(t, db, "logs", orphanQuery(), 0)
+
+	assertCount(t, db, "api_keys", bson.M{"project_id": projectID}, 1)
+	assertCount(t, db, "api_keys", orphanQuery(), 0)
+
+	// The retention value survives the move — it is the deployment's setting,
+	// now scoped to the project that inherited the data.
+	var retention struct {
+		Value int `bson:"value"`
+	}
+	if err := db.Collection("settings").FindOne(ctx, bson.M{"project_id": projectID, "key": "retention_days"}).Decode(&retention); err != nil {
+		t.Fatalf("migrated settings: %v", err)
+	}
+	if retention.Value != 30 {
+		t.Errorf("retention_days = %d, want 30 (the pre-migration value)", retention.Value)
+	}
+
+	// Both allowlisted logins own the project, with their case preserved.
+	for _, login := range []string{"alice", "Bob"} {
+		var member data.ProjectMember
+		err := db.Collection("project_members").FindOne(ctx, bson.M{"project_id": project.ID, "github_login": login}).Decode(&member)
+		if err != nil {
+			t.Fatalf("membership for %q: %v", login, err)
+		}
+		if member.Role != data.RoleOwner {
+			t.Errorf("member %q role = %q, want %q", login, member.Role, data.RoleOwner)
+		}
+	}
+
+	if hasIndex(t, db, "logs", "ttl_created_at") {
+		t.Error("the legacy global TTL index should be dropped — it would override per-project retention")
+	}
+
+	// --- Second boot: idempotent ---
+
+	startLogger(t, mongoURI, "alice,Bob,carol")
+
+	assertCount(t, db, "projects", bson.M{"slug": data.DefaultProjectSlug}, 1)
+	assertCount(t, db, "logs", bson.M{"project_id": projectID}, 3)
+	assertCount(t, db, "api_keys", bson.M{"project_id": projectID}, 1)
+	assertCount(t, db, "settings", bson.M{"project_id": projectID, "key": "retention_days"}, 1)
+
+	// With no orphans left there is nothing to migrate, so the login added to the
+	// allowlist since the first boot must not be granted ownership.
+	assertCount(t, db, "project_members", bson.M{"project_id": project.ID}, 2)
+}
+
+// TestStartupMigration_CleanDatabase verifies a fresh install is left alone:
+// no data means no orphans, so no Default project is invented.
+func TestStartupMigration_CleanDatabase(t *testing.T) {
+	ctx := context.Background()
+	mongoURI, client := startMongo(t)
+	db := client.Database("logs")
+
+	startLogger(t, mongoURI, "alice")
+
+	n, err := db.Collection("projects").CountDocuments(ctx, bson.M{})
+	if err != nil {
+		t.Fatalf("count projects: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("clean database: got %d projects, want 0 — the migration should skip silently", n)
+	}
+}
+
+// TestStartupMigration_LegacyDataReadableThroughBroker is the automated form of
+// the upgrade check: seed a database as a pre-multi-tenancy build left it, boot
+// the whole stack, and read the old events back through the public API using the
+// old API key. Nothing in the request mentions a project — the key carries the
+// one the migration adopted it into.
+func TestStartupMigration_LegacyDataReadableThroughBroker(t *testing.T) {
+	ctx := context.Background()
+	mongoURI, client := startMongo(t)
+	db := client.Database("logs")
+
+	legacy := []interface{}{
+		bson.M{"name": "legacy-event-a", "data": "{}", "severity": "INFO", "created_at": time.Now(), "updated_at": time.Now()},
+		bson.M{"name": "legacy-event-b", "data": "{}", "severity": "ERROR", "created_at": time.Now(), "updated_at": time.Now()},
+	}
+	if _, err := db.Collection("logs").InsertMany(ctx, legacy); err != nil {
+		t.Fatalf("seed logs: %v", err)
+	}
+
+	legacyKey := seedLegacyAPIKey(t, db, "lw_legacykey00000000001")
+
+	rabbitC, err := rabbitmq.Run(ctx, "rabbitmq:3.9-alpine")
+	if err != nil {
+		t.Fatalf("rabbitmq container: %v", err)
+	}
+	t.Cleanup(func() { rabbitC.Terminate(context.Background()) })
+	rabbitURI, _ := rabbitC.AmqpURL(ctx)
+
+	brokerURL := startStack(t, mongoURI, rabbitURI)
+
+	names := getLogs(t, brokerURL, legacyKey)
+	for _, want := range []string{"legacy-event-a", "legacy-event-b"} {
+		if !containsName(names, want) {
+			t.Errorf("legacy key should read %q after migration, got %v", want, names)
+		}
+	}
+}
+
+// --- helpers ---
+
+// startMongo launches a throwaway MongoDB with the credentials Logger expects
+// and returns its URI plus a connected client for seeding and assertions.
+func startMongo(t *testing.T) (string, *mongo.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mongo:4.2.16-bionic",
+			ExposedPorts: []string{"27017/tcp"},
+			Env: map[string]string{
+				"MONGO_INITDB_ROOT_USERNAME": "admin",
+				"MONGO_INITDB_ROOT_PASSWORD": "password",
+			},
+			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("mongo container: %v", err)
+	}
+	t.Cleanup(func() { mongoC.Terminate(context.Background()) })
+
+	host, _ := mongoC.Host(ctx)
+	port, _ := mongoC.MappedPort(ctx, "27017")
+	uri := fmt.Sprintf("mongodb://admin:password@%s:%s", host, port.Port())
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri).
+		SetAuth(options.Credential{Username: "admin", Password: "password"}))
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	t.Cleanup(func() { client.Disconnect(context.Background()) })
+
+	return uri, client
+}
+
+// startLogger boots Logger and returns once its RPC port accepts connections,
+// which only happens after the startup migration has run.
+func startLogger(t *testing.T, mongoURI, allowedUsers string) {
+	t.Helper()
+
+	rpcAddr := freeAddr(t)
+	httpAddr := freeAddr(t)
+
+	startProcess(t, "../logger/cmd/api", map[string]string{
+		"MONGO_URL":                    mongoURI,
+		"LOGGER_RPC_PORT":              portOf(rpcAddr),
+		"LOGGER_HTTP_PORT":             portOf(httpAddr),
+		"LOGWOLF_ALLOWED_GITHUB_USERS": allowedUsers,
+		// Keep the retention loop out of the way of the assertions.
+		"CLEANUP_INTERVAL": "24h",
+	})
+
+	waitForTCP(t, rpcAddr, 60*time.Second)
+}
+
+func requireDefaultProject(t *testing.T, db *mongo.Database) data.Project {
+	t.Helper()
+
+	var project data.Project
+	err := db.Collection("projects").FindOne(context.Background(), bson.M{"slug": data.DefaultProjectSlug}).Decode(&project)
+	if err != nil {
+		t.Fatalf("the migration should have created the %q project: %v", data.DefaultProjectSlug, err)
+	}
+	if project.Name != data.DefaultProjectName {
+		t.Errorf("project name = %q, want %q", project.Name, data.DefaultProjectName)
+	}
+	return project
+}
+
+// orphanQuery matches documents the migration should have left none of.
+func orphanQuery() bson.M {
+	return bson.M{"$or": []bson.M{
+		{"project_id": bson.M{"$exists": false}},
+		{"project_id": nil},
+		{"project_id": ""},
+	}}
+}
+
+func assertCount(t *testing.T, db *mongo.Database, collection string, filter bson.M, want int64) {
+	t.Helper()
+
+	got, err := db.Collection(collection).CountDocuments(context.Background(), filter)
+	if err != nil {
+		t.Fatalf("count %s: %v", collection, err)
+	}
+	if got != want {
+		t.Errorf("%s matching %v: got %d, want %d", collection, filter, got, want)
+	}
+}
+
+func hasIndex(t *testing.T, db *mongo.Database, collection, name string) bool {
+	t.Helper()
+	ctx := context.Background()
+
+	cursor, err := db.Collection(collection).Indexes().List(ctx)
+	if err != nil {
+		t.Fatalf("list indexes on %s: %v", collection, err)
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		var idx bson.M
+		if err := cursor.Decode(&idx); err != nil {
+			continue
+		}
+		if idx["name"] == name {
+			return true
+		}
+	}
+	return false
+}
+
+// seedLegacyAPIKey inserts an API key in the pre-multi-tenancy shape — a usable
+// bcrypt hash, no project_id — and returns its plaintext.
+func seedLegacyAPIKey(t *testing.T, db *mongo.Database, plaintext string) string {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("seedLegacyAPIKey: bcrypt: %v", err)
+	}
+
+	_, err = db.Collection("api_keys").InsertOne(context.Background(), bson.M{
+		"prefix":     plaintext[:10],
+		"hash":       string(hash),
+		"active":     true,
+		"created_at": time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("seedLegacyAPIKey: insert: %v", err)
+	}
+
+	return plaintext
+}

--- a/logwolf-server/logger/cmd/api/main.go
+++ b/logwolf-server/logger/cmd/api/main.go
@@ -49,6 +49,13 @@ func main() {
 	if err := app.Models.EnsureLogsIndexes(); err != nil {
 		log.Printf("Warning: could not ensure logs indexes: %v", err)
 	}
+	if err := app.Models.EnsureProjectIndexes(); err != nil {
+		log.Printf("Warning: could not ensure project indexes: %v", err)
+	}
+
+	// Adopt any data that predates projects before the RPC server comes up, so no
+	// caller ever reads a half-migrated database.
+	app.runStartupMigration()
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()

--- a/logwolf-server/logger/cmd/api/migrate.go
+++ b/logwolf-server/logger/cmd/api/migrate.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"log"
+	"logwolf-toolbox/data"
+	"os"
+	"time"
+)
+
+// migrationTimeout bounds the whole startup migration. A large logs collection
+// takes a while to stamp, but startup must not hang forever.
+const migrationTimeout = 5 * time.Minute
+
+// allowedGithubUsers returns the dashboard allowlist. It is the only signal the
+// logger has for who should own data that predates projects.
+func allowedGithubUsers() []string {
+	return data.ParseGithubLogins(os.Getenv("LOGWOLF_ALLOWED_GITHUB_USERS"))
+}
+
+// runStartupMigration adopts any pre-multi-tenancy data into the Default project
+// before the RPC server starts accepting connections. It is silent when there is
+// nothing to migrate.
+//
+// Failures are logged rather than fatal: the migration is idempotent, so a
+// crash-looping logger helps nobody when the next start would retry anyway.
+func (app *Config) runStartupMigration() {
+	ctx, cancel := context.WithTimeout(context.Background(), migrationTimeout)
+	defer cancel()
+
+	if dropped, err := app.Models.DropLegacyTTLIndex(ctx); err != nil {
+		log.Printf("Migration: could not drop the legacy TTL index: %v", err)
+	} else if dropped {
+		log.Println("Migration: dropped the legacy global TTL index on logs — retention is per project now")
+	}
+
+	owners := allowedGithubUsers()
+
+	report, err := app.Models.MigrateOrphansToDefaultProject(ctx, owners)
+	if err != nil {
+		log.Printf("Migration: FAILED — data without a project stays invisible until this succeeds: %v", err)
+	}
+	if report == nil {
+		return
+	}
+
+	log.Printf("Migration: adopted pre-multi-tenancy data into project %q project_id=%s logs=%d api_keys=%d settings=%d owners=%d",
+		data.DefaultProjectName, report.ProjectID, report.Logs, report.APIKeys, report.Settings, report.Owners)
+
+	if len(owners) == 0 {
+		log.Printf("Migration: WARNING — LOGWOLF_ALLOWED_GITHUB_USERS is empty, so project %q has no owners; nobody can see the migrated data until a member is added",
+			data.DefaultProjectName)
+	}
+}

--- a/logwolf-server/logger/docs/OVERVIEW.md
+++ b/logwolf-server/logger/docs/OVERVIEW.md
@@ -11,7 +11,9 @@ The only Logwolf service with direct MongoDB access. All reads, writes, and dele
 
 ```
 cmd/api/
-├── main.go     # MongoDB setup, TTL index, dual-server startup, graceful shutdown
+├── main.go     # MongoDB setup, indexes, startup migration, dual-server startup, graceful shutdown
+├── migrate.go  # Startup migration of pre-multi-tenancy data into the Default project
+├── cleanup.go  # Background per-project retention cleanup loop
 ├── routes.go   # HTTP route handlers (health check only)
 └── rpc.go      # RPCServer type and all RPC method implementations
 ```
@@ -40,19 +42,36 @@ Each log entry stored in MongoDB contains:
 | Field        | Type      | Description                    |
 | ------------ | --------- | ------------------------------ |
 | `_id`        | ObjectID  | MongoDB document ID            |
+| `project_id` | string    | Owning project (hex ObjectID)  |
 | `name`       | string    | Event name                     |
 | `data`       | any       | Arbitrary payload              |
 | `severity`   | string    | `INFO`, `WARNING`, or `ERROR`  |
 | `tags`       | []string  | Searchable tags                |
 | `duration`   | int64     | Duration in milliseconds       |
-| `created_at` | time.Time | Timestamp (used for TTL index) |
+| `created_at` | time.Time | Timestamp (drives retention)   |
 | `updated_at` | time.Time | Last update timestamp          |
 
-## TTL index
+## Retention
 
-On startup, Logger ensures a TTL index on the `created_at` field of the `logs` collection. The TTL is driven by the retention setting (default 90 days). When the retention setting is updated via Broker's admin API, the index is recreated with the new value.
+Retention is a per-project setting (default 90 days; supported values 30, 60, 90, 180, 365, or 0 for forever). A background loop deletes expired logs project by project every `CLEANUP_INTERVAL`.
 
-Supported retention values: 30, 60, 90, 180, 365 days.
+Pre-multi-tenancy builds enforced retention with a single global TTL index on `logs.created_at`. That index is dropped on startup — left in place it would keep expiring logs on the old global schedule, overriding whatever each project now has configured.
+
+## Startup migration
+
+Before the RPC server accepts connections, Logger adopts any data written by a pre-multi-tenancy build:
+
+1. Count documents in `logs`, `api_keys`, and `settings` that carry no project ID. If there are none, nothing happens and nothing is logged.
+2. Otherwise, find or create a project named `Default` (slug `default`).
+3. Stamp every orphaned document with that project's ID.
+4. Give each login in `LOGWOLF_ALLOWED_GITHUB_USERS` an owner membership on the project, leaving existing memberships alone.
+5. Log a summary line with the project ID and the per-collection counts.
+
+The migration is idempotent — once no orphaned documents remain it is a no-op, so it runs safely on every start. A run that fails partway leaves the rest for the next start and does not stop the service from booting; the failure is logged as `Migration: FAILED`.
+
+During an upgrade, a Broker that validated an API key just before the migration caches that key's project (still empty at the time) for up to 60 seconds, so reads with it can come back empty until the entry expires.
+
+An empty `LOGWOLF_ALLOWED_GITHUB_USERS` still migrates the data, but the Default project ends up with no owners and stays invisible in the dashboard until a member is added. The migration logs a warning when this happens. Logins allowed only through `LOGWOLF_ALLOWED_GITHUB_ORGS` are not enrolled — the org membership is not visible from Logger.
 
 ## Graceful shutdown
 
@@ -60,11 +79,13 @@ The HTTP server has a 15-second shutdown timeout. The RPC server closes its TCP 
 
 ## Environment variables
 
-| Variable           | Default                 | Description                 |
-| ------------------ | ----------------------- | --------------------------- |
-| `MONGO_URL`        | `mongodb://mongo:27017` | MongoDB connection string   |
-| `LOGGER_RPC_PORT`  | `5001`                  | TCP port for the RPC server |
-| `LOGGER_HTTP_PORT` | `80`                    | HTTP port for health checks |
+| Variable                       | Default                 | Description                                                              |
+| ------------------------------ | ----------------------- | ------------------------------------------------------------------------ |
+| `MONGO_URL`                    | `mongodb://mongo:27017` | MongoDB connection string                                                |
+| `LOGGER_RPC_PORT`              | `5001`                  | TCP port for the RPC server                                              |
+| `LOGGER_HTTP_PORT`             | `80`                    | HTTP port for health checks                                              |
+| `CLEANUP_INTERVAL`             | `1h`                    | How often the per-project retention cleanup runs                         |
+| `LOGWOLF_ALLOWED_GITHUB_USERS` | —                       | Comma-separated logins made owners of `Default` by the startup migration |
 
 ## Key dependencies
 

--- a/logwolf-server/toolbox/data/migrate.go
+++ b/logwolf-server/toolbox/data/migrate.go
@@ -1,0 +1,234 @@
+package data
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// The project that pre-multi-tenancy data is adopted into on first start.
+const (
+	DefaultProjectName = "Default"
+	DefaultProjectSlug = "default"
+)
+
+// legacyTTLIndexName is the global TTL index used before retention became a
+// per-project setting enforced by the logger's cleanup loop.
+const legacyTTLIndexName = "ttl_created_at"
+
+// MongoDB error codes for dropping an index that was never there: the index is
+// missing, or the collection itself has not been created yet.
+const (
+	indexNotFound     = 27
+	namespaceNotFound = 26
+)
+
+// OrphanCounts reports how many documents in each project-scoped collection
+// were written before project scoping existed.
+type OrphanCounts struct {
+	Logs     int64
+	APIKeys  int64
+	Settings int64
+}
+
+// Total is the number of orphaned documents across all collections.
+func (c OrphanCounts) Total() int64 {
+	return c.Logs + c.APIKeys + c.Settings
+}
+
+// MigrationReport summarises one run of MigrateOrphansToDefaultProject: the
+// project the data was adopted into, and how much of it moved.
+type MigrationReport struct {
+	ProjectID string
+	Logs      int64
+	APIKeys   int64
+	Settings  int64
+	Owners    int64
+}
+
+// orphanedFilter matches documents written before project scoping existed. A
+// pre-multi-tenancy document has no project_id at all; the null and empty-string
+// cases cover data half-written by a build in between.
+func orphanedFilter() bson.M {
+	return bson.M{"$or": []bson.M{
+		{"project_id": bson.M{"$exists": false}},
+		{"project_id": nil},
+		{"project_id": ""},
+	}}
+}
+
+// ParseGithubLogins splits a comma-separated allowlist (as used by
+// LOGWOLF_ALLOWED_GITHUB_USERS) into logins, dropping blanks and duplicates.
+//
+// Case is preserved: memberships are matched against the login GitHub returns
+// at sign-in, exactly as the dashboard allowlist compares it.
+func ParseGithubLogins(raw string) []string {
+	var logins []string
+	seen := make(map[string]bool)
+
+	for _, part := range strings.Split(raw, ",") {
+		login := strings.TrimSpace(part)
+		if login == "" || seen[login] {
+			continue
+		}
+		seen[login] = true
+		logins = append(logins, login)
+	}
+
+	return logins
+}
+
+// CountOrphanedDocuments counts the documents in each project-scoped collection
+// that carry no project ID.
+func (m *Models) CountOrphanedDocuments(ctx context.Context) (OrphanCounts, error) {
+	var counts OrphanCounts
+
+	for _, c := range []struct {
+		collection string
+		into       *int64
+	}{
+		{"logs", &counts.Logs},
+		{"api_keys", &counts.APIKeys},
+		{"settings", &counts.Settings},
+	} {
+		n, err := m.client.Database("logs").Collection(c.collection).CountDocuments(ctx, orphanedFilter())
+		if err != nil {
+			return counts, fmt.Errorf("CountOrphanedDocuments %s: %w", c.collection, err)
+		}
+		*c.into = n
+	}
+
+	return counts, nil
+}
+
+// MigrateOrphansToDefaultProject adopts pre-multi-tenancy logs, API keys, and
+// settings into a project named "Default", creating that project and an owner
+// membership for each of owners if they do not exist yet.
+//
+// It is idempotent: it does nothing and returns a nil report once no orphaned
+// documents remain, so it is safe to run on every start. A partially completed
+// run leaves the remaining orphans behind for the next start to finish.
+func (m *Models) MigrateOrphansToDefaultProject(ctx context.Context, owners []string) (*MigrationReport, error) {
+	counts, err := m.CountOrphanedDocuments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if counts.Total() == 0 {
+		return nil, nil
+	}
+
+	project, err := m.ensureDefaultProject()
+	if err != nil {
+		return nil, err
+	}
+
+	report := &MigrationReport{ProjectID: project.ID.Hex()}
+
+	// The report is returned alongside any error: a run that fails partway still
+	// moved whatever it reports, and the caller should say so.
+	if report.Logs, err = m.adoptOrphans(ctx, "logs", report.ProjectID); err != nil {
+		return report, err
+	}
+	if report.APIKeys, err = m.adoptOrphans(ctx, "api_keys", report.ProjectID); err != nil {
+		return report, err
+	}
+	if report.Settings, err = m.adoptOrphans(ctx, "settings", report.ProjectID); err != nil {
+		return report, err
+	}
+
+	report.Owners, err = m.ensureOwners(ctx, project.ID, owners)
+	if err != nil {
+		return report, err
+	}
+
+	return report, nil
+}
+
+// adoptOrphans stamps every project-less document in collection with projectID.
+func (m *Models) adoptOrphans(ctx context.Context, collection, projectID string) (int64, error) {
+	result, err := m.client.Database("logs").Collection(collection).UpdateMany(
+		ctx,
+		orphanedFilter(),
+		bson.M{"$set": bson.M{"project_id": projectID}},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("adoptOrphans %s: %w", collection, err)
+	}
+	return result.ModifiedCount, nil
+}
+
+// ensureDefaultProject returns the Default project, creating it if needed.
+func (m *Models) ensureDefaultProject() (*Project, error) {
+	existing, err := m.GetProjectBySlug(DefaultProjectSlug)
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, fmt.Errorf("ensureDefaultProject: %w", err)
+	}
+
+	created, err := m.InsertProject(Project{Name: DefaultProjectName, Slug: DefaultProjectSlug})
+	if err == nil {
+		return created, nil
+	}
+	// Another logger instance created it first — the unique slug index caught it.
+	if mongo.IsDuplicateKeyError(err) {
+		return m.GetProjectBySlug(DefaultProjectSlug)
+	}
+	return nil, fmt.Errorf("ensureDefaultProject: %w", err)
+}
+
+// ensureOwners gives each login an owner membership on the project, leaving any
+// membership that already exists untouched. Returns how many were created.
+func (m *Models) ensureOwners(ctx context.Context, projectID primitive.ObjectID, logins []string) (int64, error) {
+	collection := m.client.Database("logs").Collection("project_members")
+	var created int64
+
+	for _, login := range logins {
+		result, err := collection.UpdateOne(
+			ctx,
+			bson.M{"project_id": projectID, "github_login": login},
+			bson.M{"$setOnInsert": bson.M{
+				"project_id":   projectID,
+				"github_login": login,
+				"role":         RoleOwner,
+				"created_at":   time.Now(),
+			}},
+			options.Update().SetUpsert(true),
+		)
+		if err != nil {
+			return created, fmt.Errorf("ensureOwners %s: %w", login, err)
+		}
+		if result.UpsertedCount > 0 {
+			created++
+		}
+	}
+
+	return created, nil
+}
+
+// DropLegacyTTLIndex removes the global TTL index that pre-multi-tenancy builds
+// kept on logs.created_at. Retention is per project now, so leaving the old
+// index in place would keep expiring logs on the previous global schedule no
+// matter what a project has configured.
+//
+// Reports whether an index was actually dropped; dropping a missing index is
+// not an error, so this is safe to call on every start.
+func (m *Models) DropLegacyTTLIndex(ctx context.Context) (bool, error) {
+	_, err := m.client.Database("logs").Collection("logs").Indexes().DropOne(ctx, legacyTTLIndexName)
+	if err != nil {
+		var cmdErr mongo.CommandError
+		if errors.As(err, &cmdErr) && (cmdErr.Code == indexNotFound || cmdErr.Code == namespaceNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("DropLegacyTTLIndex: %w", err)
+	}
+	return true, nil
+}

--- a/logwolf-server/toolbox/data/migrate_test.go
+++ b/logwolf-server/toolbox/data/migrate_test.go
@@ -1,0 +1,78 @@
+package data
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestParseGithubLogins(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"only separators", " , ,, ", nil},
+		{"single", "jpricardo", []string{"jpricardo"}},
+		{"comma separated", "alice,bob", []string{"alice", "bob"}},
+		{"trims spaces", " alice , bob ", []string{"alice", "bob"}},
+		{"drops blanks", "alice,,bob,", []string{"alice", "bob"}},
+		{"drops duplicates", "alice,bob,alice", []string{"alice", "bob"}},
+		{"preserves case", "JPRicardo", []string{"JPRicardo"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseGithubLogins(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseGithubLogins(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ParseGithubLogins(%q)[%d] = %q, want %q", tt.raw, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestParseGithubLogins_CaseIsSignificant guards the reason case is preserved:
+// project_members lookups match the login GitHub returns at sign-in exactly, so
+// folding case here would leave a mixed-case user locked out of the project the
+// migration created for them.
+func TestParseGithubLogins_CaseIsSignificant(t *testing.T) {
+	got := ParseGithubLogins("Alice,alice")
+	if len(got) != 2 {
+		t.Fatalf("ParseGithubLogins should treat differently-cased logins as distinct, got %v", got)
+	}
+}
+
+// TestOrphanedFilterMatchesLegacyShapes verifies the filter covers every shape a
+// pre-project document can have: no project_id, an explicit null, or an empty
+// string — and nothing else.
+func TestOrphanedFilterMatchesLegacyShapes(t *testing.T) {
+	clauses, ok := orphanedFilter()["$or"].([]bson.M)
+	if !ok {
+		t.Fatalf("orphanedFilter: $or should be a []bson.M, got %T", orphanedFilter()["$or"])
+	}
+
+	if len(clauses) != 3 {
+		t.Errorf("orphanedFilter: got %d conditions, want 3 (missing, null, empty)", len(clauses))
+	}
+	for _, c := range clauses {
+		if _, ok := c["project_id"]; !ok {
+			t.Errorf("orphanedFilter: every condition should be on project_id, got %v", c)
+		}
+	}
+}
+
+func TestOrphanCountsTotal(t *testing.T) {
+	c := OrphanCounts{Logs: 12, APIKeys: 3, Settings: 1}
+	if c.Total() != 16 {
+		t.Errorf("Total() = %d, want 16", c.Total())
+	}
+	if (OrphanCounts{}).Total() != 0 {
+		t.Error("zero OrphanCounts should total 0")
+	}
+}

--- a/logwolf-server/toolbox/docs/OVERVIEW.md
+++ b/logwolf-server/toolbox/docs/OVERVIEW.md
@@ -13,7 +13,9 @@ toolbox/
 ├── data/
 │   ├── models.go    # Models struct, LogEntry, APIKey, Settings types + CRUD methods
 │   ├── apikey.go    # APIKey model, key generation, validation
-│   ├── settings.go  # TTL/retention settings, index management
+│   ├── settings.go  # Per-project retention settings, index management
+│   ├── project.go   # Project and ProjectMember models, membership queries
+│   ├── migrate.go   # Startup migration of pre-multi-tenancy data
 │   └── log.go       # Log entry type aliases
 ├── event/
 │   ├── event.go     # Exchange + queue declarations
@@ -51,7 +53,20 @@ Stores API key metadata: key value (hashed), label, created/last-used timestamps
 
 ### `Settings`
 
-Manages the single-document settings record (currently: retention TTL in days). Also owns the logic for creating/dropping the MongoDB TTL index when retention changes.
+Manages per-project settings documents (currently: retention in days), keyed by `(project_id, key)`.
+
+### Startup migration (`migrate.go`)
+
+Adopts data written before projects existed. Logger calls it on every start; Broker and Listener never do.
+
+| Function                         | Description                                                                             |
+| -------------------------------- | --------------------------------------------------------------------------------------- |
+| `CountOrphanedDocuments`         | Counts `logs`, `api_keys`, and `settings` documents with no project ID                  |
+| `MigrateOrphansToDefaultProject` | Adopts those documents into the `Default` project, creating it and its owners if needed |
+| `DropLegacyTTLIndex`             | Removes the global TTL index that predates per-project retention                        |
+| `ParseGithubLogins`              | Splits a comma-separated allowlist into logins (trimmed, deduplicated, case preserved)  |
+
+`MigrateOrphansToDefaultProject` returns a nil `*MigrationReport` when there is nothing to adopt, which is what makes repeated runs a no-op.
 
 ## `event` package
 


### PR DESCRIPTION
Closes #18.

Existing deployments have `logs`, `api_keys`, and `settings` with no `project_id`. Without a migration, shipping multi-tenancy makes all of that data invisible. Logger now adopts it into a `Default` project before it serves traffic.

## How it works

`toolbox/data/migrate.go` holds the DB-level work:

- `CountOrphanedDocuments` counts documents whose `project_id` is missing, null, or an empty string
- `MigrateOrphansToDefaultProject` returns a **nil report and does nothing** when that count is zero — this is what makes reruns a no-op. Otherwise it finds-or-creates project `Default` / `default` (duplicate-key safe), stamps each collection with `UpdateMany`, then upserts an owner `ProjectMember` per allowlisted login with `$setOnInsert`, so an existing membership is never downgraded
- `ParseGithubLogins` trims and dedupes `LOGWOLF_ALLOWED_GITHUB_USERS` but **preserves case** — memberships are matched against the login GitHub returns at sign-in, so folding case would lock a mixed-case user out of the project created for them

`logger/cmd/api/migrate.go` reads the env var, logs the summary, and warns when the allowlist is empty (the project would have no owners and stay invisible in the dashboard). It is called from `main.go` before `serve()`, so the RPC port only opens on a fully migrated database. Failures are logged rather than fatal — the migration is idempotent, so the next start retries instead of crash-looping the stack.

## Two additions beyond the issue text

1. **`EnsureProjectIndexes()` was never called in production** — only from an integration test, so the unique `slug` index did not exist on a real deployment. The migration's find-or-create relies on it. Now called at logger startup.
2. **The legacy TTL index is dropped.** An upgraded deployment still carries the pre-multi-tenancy global TTL index on `logs.created_at`; left in place it keeps purging on the old global schedule and overrides per-project retention (a project set to "forever" would still lose data).

`docker-compose.yml` now passes `LOGWOLF_ALLOWED_GITHUB_USERS` to logger — without it an upgrade migrates the data but leaves the `Default` project ownerless.

## Also bundled (not part of #18)

Two unrelated fixes rode along on this branch; they are independent and can be reviewed separately:

- **`CLEANUP_INTERVAL` never reached the logger container.** It was documented in `.env.example` but absent from `docker-compose.yml`, so setting it had no effect. Also added CI steps for the logger and listener modules — `logger/cmd/api/rpc_test.go` existed but had never run in CI.
- **The integration harness leaked service processes.** `startProcess` ran services via `go run` and killed only that parent; on Windows the service survived. Strays accumulated across runs and a stray Listener reconnecting to a recycled RabbitMQ port ate messages a later test was waiting for, causing false failures in the `TestProjectIsolation_*` tests. `startProcess` now builds each service once and execs the binary directly, so the killed process is the service.

## Verification

- Unit tests: broker, toolbox (including new `migrate_test.go`), logger — all pass
- Integration suite: **24/24**, run twice back-to-back with no cleanup between runs, leaving zero stray processes
- New `integration/startup_migration_test.go` seeds a pre-multi-tenancy database, boots the **real logger**, and asserts after the RPC port opens; a second boot with an extra allowlist entry proves idempotency; a third test reads the legacy events back through the broker's public `GET /logs` using the legacy API key
- Manual boot against a seeded database, confirming ordering and log wording:

```
Migration: dropped the legacy global TTL index on logs — retention is per project now
Migration: adopted pre-multi-tenancy data into project "Default" project_id=6a89d492354cc53eb0a477fe logs=2 api_keys=1 settings=1 owners=2
Starting RPC server on port 35001
```

A second boot printed nothing.

## Note for upgrades

The broker caches an API key's project for 60s, so a key validated in the seconds before the migration can read empty until that entry expires. Self-healing; documented in the logger overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
