### PR TITLE
test(#19): project isolation coverage across unit and integration suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         working-directory: logwolf-server/toolbox
         run: go test ./... -v -count=1
 
+      - name: Run logger unit tests
+        working-directory: logwolf-server/logger
+        run: go test ./... -v -count=1
+
   test-integration:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,16 @@ Managed as a Go workspace (`logwolf-server/go.work`):
 # Run a service locally
 cd logwolf-server/broker && go run ./cmd/api
 
-# Unit tests (broker + toolbox)
+# Unit tests (broker + toolbox + logger)
 cd logwolf-server/broker && go test ./cmd/api/... -v
 cd logwolf-server/toolbox && go test ./... -v
+cd logwolf-server/logger && go test ./... -v
 
 # Integration tests (requires Docker — spins up real MongoDB + RabbitMQ)
 cd logwolf-server/integration && go test -tags integration ./... -v -timeout 5m
+
+# ...with the service subprocesses' output on stderr, when the stack won't come up
+LOGWOLF_TEST_VERBOSE=1 go test -tags integration ./... -v -timeout 5m
 ```
 
 ### JS SDK (`logwolf-client/js`)
@@ -151,7 +155,7 @@ The frontend instruments itself with `@logwolf/client-js` (`lib/logwolf.ts`) for
 
 GitHub Actions (`.github/workflows/ci.yml`) runs on every push to `main` and all PRs:
 
-1. Go unit tests (broker + toolbox)
+1. Go unit tests (broker + toolbox + logger)
 2. Integration tests
 3. JS SDK tests
 

--- a/logwolf-server/broker/cmd/api/fakelogger_test.go
+++ b/logwolf-server/broker/cmd/api/fakelogger_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/rpc"
+	"sync"
+	"testing"
+
+	"logwolf-toolbox/data"
+)
+
+// fakeLogger stands in for the Logger service over a real net/rpc connection.
+//
+// The broker's project handlers dial the logger themselves — the address comes
+// from LOGGER_RPC_ADDR, not from Config — so the only way to exercise the
+// membership checks is to put a server on the other end of that dial. Serving
+// the same method set over gob keeps the wire contract (including net/rpc's
+// flattening of errors into strings, which the broker matches on) intact.
+//
+// All exported methods must be RPC-shaped; helpers for the tests are unexported
+// so net/rpc ignores them.
+type fakeLogger struct {
+	mu sync.Mutex
+
+	projects  map[string]data.Project         // project id hex -> project
+	members   map[string][]data.ProjectMember // project id hex -> members
+	logs      map[string][]data.LogEntry      // project id hex -> logs
+	retention map[string]int                  // project id hex -> days
+	metrics   map[string]data.Metrics         // project id hex -> metrics
+
+	// Recorded calls, for asserting what the broker forwarded.
+	getLogsParams   []data.QueryParams
+	retentionArgs   []data.RetentionArgs
+	metricsArgs     []data.ProjectArgs
+	createdProjects []data.RPCCreateProjectArgs
+	updatedProjects []data.RPCUpdateProjectArgs
+	deletedProjects []string
+	addedMembers    []data.RPCAddMemberArgs
+	removedMembers  []data.RPCRemoveMemberArgs
+
+	// Failure injection.
+	duplicateSlug  string // CreateProject returns an E11000 error for this slug
+	failAddMember  bool   // AddMember always fails (exercises the create-project rollback)
+	lastOwnerLogin string // RemoveMember refuses to remove this login
+}
+
+// errNoDocuments mirrors the driver error the logger passes back when a lookup
+// misses. The broker only sees the message, so the wording is the contract.
+var errNoDocuments = errors.New("mongo: no documents in result set")
+
+func newFakeLogger() *fakeLogger {
+	return &fakeLogger{
+		projects:  map[string]data.Project{},
+		members:   map[string][]data.ProjectMember{},
+		logs:      map[string][]data.LogEntry{},
+		retention: map[string]int{},
+		metrics:   map[string]data.Metrics{},
+	}
+}
+
+// --- RPC surface ---
+
+func (f *fakeLogger) GetProject(args *data.RPCProjectIDArgs, reply *data.Project) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	p, ok := f.projects[args.ID]
+	if !ok {
+		return errNoDocuments
+	}
+	*reply = p
+	return nil
+}
+
+func (f *fakeLogger) CreateProject(args *data.RPCCreateProjectArgs, reply *data.Project) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.createdProjects = append(f.createdProjects, *args)
+	if args.Slug == f.duplicateSlug {
+		return fmt.Errorf("E11000 duplicate key error collection: logs.projects index: slug_1")
+	}
+
+	id := nextProjectID()
+	p := data.Project{ID: mustObjectID(id), Name: args.Name, Slug: args.Slug}
+	f.projects[id] = p
+	*reply = p
+	return nil
+}
+
+func (f *fakeLogger) UpdateProject(args *data.RPCUpdateProjectArgs, reply *data.Project) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.updatedProjects = append(f.updatedProjects, *args)
+	p, ok := f.projects[args.ID]
+	if !ok {
+		return errNoDocuments
+	}
+	p.Name, p.Slug = args.Name, args.Slug
+	f.projects[args.ID] = p
+	*reply = p
+	return nil
+}
+
+func (f *fakeLogger) DeleteProject(args *data.RPCProjectIDArgs, reply *string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.deletedProjects = append(f.deletedProjects, args.ID)
+	delete(f.projects, args.ID)
+	delete(f.members, args.ID)
+	delete(f.logs, args.ID)
+	delete(f.retention, args.ID)
+	*reply = "ok"
+	return nil
+}
+
+func (f *fakeLogger) ListUserProjects(args *data.RPCUserProjectsArgs, reply *[]data.UserProject) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var out []data.UserProject
+	for id, members := range f.members {
+		for _, m := range members {
+			if m.GithubLogin != args.GithubLogin {
+				continue
+			}
+			if p, ok := f.projects[id]; ok {
+				out = append(out, data.UserProject{Project: p, Role: m.Role})
+			}
+		}
+	}
+	*reply = out
+	return nil
+}
+
+func (f *fakeLogger) ListMembers(args *data.ProjectArgs, reply *[]data.ProjectMember) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	*reply = append([]data.ProjectMember(nil), f.members[args.ProjectID]...)
+	return nil
+}
+
+func (f *fakeLogger) CheckMembership(args *data.RPCCheckMembershipArgs, reply *bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, m := range f.members[args.ProjectID] {
+		if m.GithubLogin == args.GithubLogin {
+			*reply = true
+			return nil
+		}
+	}
+	*reply = false
+	return nil
+}
+
+func (f *fakeLogger) AddMember(args *data.RPCAddMemberArgs, reply *string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.addedMembers = append(f.addedMembers, *args)
+	if f.failAddMember {
+		return fmt.Errorf("AddMember: injected failure")
+	}
+	f.members[args.ProjectID] = append(f.members[args.ProjectID], data.ProjectMember{
+		ProjectID:   mustObjectID(args.ProjectID),
+		GithubLogin: args.GithubLogin,
+		Role:        args.Role,
+	})
+	*reply = "ok"
+	return nil
+}
+
+func (f *fakeLogger) RemoveMember(args *data.RPCRemoveMemberArgs, reply *string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.removedMembers = append(f.removedMembers, *args)
+	if args.GithubLogin == f.lastOwnerLogin {
+		// data.ErrLastOwner's message, as the broker sees it over the wire.
+		return fmt.Errorf("cannot remove the last owner of a project")
+	}
+
+	kept := f.members[args.ProjectID][:0]
+	for _, m := range f.members[args.ProjectID] {
+		if m.GithubLogin != args.GithubLogin {
+			kept = append(kept, m)
+		}
+	}
+	f.members[args.ProjectID] = kept
+	*reply = "ok"
+	return nil
+}
+
+func (f *fakeLogger) GetLogs(p data.QueryParams, reply *[]data.LogEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.getLogsParams = append(f.getLogsParams, p)
+	*reply = append([]data.LogEntry(nil), f.logs[p.ProjectID]...)
+	return nil
+}
+
+func (f *fakeLogger) GetLog(filter data.RPCLogEntryFilter, reply *data.LogEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, e := range f.logs[filter.ProjectID] {
+		if e.ID == filter.ID {
+			*reply = e
+			return nil
+		}
+	}
+	return errNoDocuments
+}
+
+func (f *fakeLogger) DeleteLog(filter data.RPCLogEntryFilter, reply *int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var deleted int64
+	kept := make([]data.LogEntry, 0, len(f.logs[filter.ProjectID]))
+	for _, e := range f.logs[filter.ProjectID] {
+		if e.ID == filter.ID {
+			deleted++
+			continue
+		}
+		kept = append(kept, e)
+	}
+	f.logs[filter.ProjectID] = kept
+	*reply = deleted
+	return nil
+}
+
+func (f *fakeLogger) GetRetention(args *data.RetentionArgs, reply *int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.retentionArgs = append(f.retentionArgs, *args)
+	days, ok := f.retention[args.ProjectID]
+	if !ok {
+		days = 90
+	}
+	*reply = days
+	return nil
+}
+
+func (f *fakeLogger) UpdateRetention(args *data.RetentionArgs, reply *string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.retentionArgs = append(f.retentionArgs, *args)
+	f.retention[args.ProjectID] = args.Days
+	*reply = "ok"
+	return nil
+}
+
+func (f *fakeLogger) GetMetrics(args *data.ProjectArgs, reply *data.Metrics) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.metricsArgs = append(f.metricsArgs, *args)
+	*reply = f.metrics[args.ProjectID]
+	return nil
+}
+
+// --- test-side helpers (unexported, so net/rpc ignores them) ---
+
+func (f *fakeLogger) addProject(id, name, slug string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.projects[id] = data.Project{ID: mustObjectID(id), Name: name, Slug: slug}
+}
+
+func (f *fakeLogger) addMember(projectID, login, role string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.members[projectID] = append(f.members[projectID], data.ProjectMember{
+		ProjectID:   mustObjectID(projectID),
+		GithubLogin: login,
+		Role:        role,
+	})
+}
+
+func (f *fakeLogger) addLog(projectID, logID, name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.logs[projectID] = append(f.logs[projectID], data.LogEntry{
+		ID:        logID,
+		ProjectID: projectID,
+		Name:      name,
+		Data:      "{}",
+		Severity:  "info",
+		Tags:      []string{},
+	})
+}
+
+func (f *fakeLogger) snapshot(read func(*fakeLogger)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	read(f)
+}
+
+// serveFakeLogger publishes f on a loopback listener under the name the broker
+// calls ("RPCServer") and points LOGGER_RPC_ADDR at it for the duration of t.
+func serveFakeLogger(t *testing.T, f *fakeLogger) {
+	t.Helper()
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("RPCServer", f); err != nil {
+		t.Fatalf("register fake logger: %v", err)
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	// Accept returns as soon as the listener closes, which Cleanup handles.
+	go srv.Accept(l)
+
+	t.Setenv("LOGGER_RPC_ADDR", l.Addr().String())
+}

--- a/logwolf-server/broker/cmd/api/project_access_test.go
+++ b/logwolf-server/broker/cmd/api/project_access_test.go
@@ -1,0 +1,564 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"logwolf-toolbox/data"
+)
+
+// Project ids have to be real ObjectID hex: the logger parses them, and the
+// broker forwards whatever the path carried without touching it.
+const (
+	projAlpha   = "aaaaaaaaaaaaaaaaaaaaaaa1"
+	projBeta    = "bbbbbbbbbbbbbbbbbbbbbbb2"
+	projMissing = "ccccccccccccccccccccccc3"
+
+	alphaLogID = "1111111111111111111111a1"
+	betaLogID  = "2222222222222222222222b2"
+
+	internalSecret = "test-internal-secret"
+)
+
+var projectIDSeq atomic.Int64
+
+func nextProjectID() string {
+	return fmt.Sprintf("dddddddddddddddddddd%04d", projectIDSeq.Add(1))
+}
+
+func mustObjectID(hex string) primitive.ObjectID {
+	id, err := primitive.ObjectIDFromHex(hex)
+	if err != nil {
+		panic("test fixture: invalid ObjectID hex " + hex + ": " + err.Error())
+	}
+	return id
+}
+
+// newInternalTestServer wires the real router to a fake logger and seeds two
+// projects: alpha (owner-a, member-a) and beta (owner-b). Nobody belongs to
+// both, so any cross-project read that succeeds is an isolation failure.
+func newInternalTestServer(t *testing.T) (http.Handler, *fakeLogger) {
+	t.Helper()
+
+	f := newFakeLogger()
+	f.addProject(projAlpha, "Alpha", "alpha")
+	f.addProject(projBeta, "Beta", "beta")
+	f.addMember(projAlpha, "owner-a", data.RoleOwner)
+	f.addMember(projAlpha, "member-a", data.RoleMember)
+	f.addMember(projBeta, "owner-b", data.RoleOwner)
+	f.addLog(projAlpha, alphaLogID, "alpha-event")
+	f.addLog(projBeta, betaLogID, "beta-event")
+
+	serveFakeLogger(t, f)
+	t.Setenv("INTERNAL_API_SECRET", internalSecret)
+
+	app := &Config{}
+	return app.routes(), f
+}
+
+// internalRequest builds a request carrying both headers the internal routes
+// demand. body may be nil.
+func internalRequest(method, target, userLogin string, body any) *http.Request {
+	var r *http.Request
+	if body == nil {
+		r = httptest.NewRequest(method, target, nil)
+	} else {
+		b, _ := json.Marshal(body)
+		r = httptest.NewRequest(method, target, bytes.NewReader(b))
+		r.Header.Set("Content-Type", "application/json")
+	}
+	r.Header.Set("X-Internal-Secret", internalSecret)
+	if userLogin != "" {
+		r.Header.Set("X-User-Login", userLogin)
+	}
+	return r
+}
+
+func do(h http.Handler, r *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+// decodeData pulls the "data" member out of the standard response envelope.
+func decodeData[T any](t *testing.T, w *httptest.ResponseRecorder) T {
+	t.Helper()
+	var envelope struct {
+		Error   bool            `json:"error"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode envelope: %v (body: %s)", err, w.Body.String())
+	}
+	var out T
+	if len(envelope.Data) > 0 {
+		if err := json.Unmarshal(envelope.Data, &out); err != nil {
+			t.Fatalf("decode data: %v (body: %s)", err, w.Body.String())
+		}
+	}
+	return out
+}
+
+// --- requireInternalSecret ---
+
+func TestInternalRoutes_RejectMissingOrWrongSecret(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+
+	routes := []struct{ method, target string }{
+		{http.MethodGet, "/keys?project_id=" + projAlpha},
+		{http.MethodGet, "/settings/retention?project_id=" + projAlpha},
+		{http.MethodGet, "/metrics?project_id=" + projAlpha},
+		{http.MethodGet, "/projects"},
+		{http.MethodGet, "/projects/" + projAlpha},
+		{http.MethodDelete, "/projects/" + projAlpha},
+		{http.MethodGet, "/projects/" + projAlpha + "/members"},
+		{http.MethodGet, "/projects/" + projAlpha + "/logs"},
+		{http.MethodGet, "/projects/" + projAlpha + "/logs/" + alphaLogID},
+	}
+
+	for _, route := range routes {
+		for _, secret := range []string{"", "wrong-secret"} {
+			r := httptest.NewRequest(route.method, route.target, nil)
+			if secret != "" {
+				r.Header.Set("X-Internal-Secret", secret)
+			}
+			r.Header.Set("X-User-Login", "owner-a")
+
+			if w := do(handler, r); w.Code != http.StatusUnauthorized {
+				t.Errorf("%s %s with secret %q: got %d, want 401", route.method, route.target, secret, w.Code)
+			}
+		}
+	}
+}
+
+func TestInternalRoutes_SecretUnsetRejectsEverything(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+	// An unset server-side secret must fail closed rather than match the
+	// empty header a caller can trivially send.
+	t.Setenv("INTERNAL_API_SECRET", "")
+
+	r := httptest.NewRequest(http.MethodGet, "/projects", nil)
+	r.Header.Set("X-User-Login", "owner-a")
+
+	if w := do(handler, r); w.Code != http.StatusUnauthorized {
+		t.Errorf("unset INTERNAL_API_SECRET: got %d, want 401", w.Code)
+	}
+}
+
+// --- requireUserLogin ---
+
+func TestInternalRoutes_RejectMissingUserLogin(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+
+	routes := []struct{ method, target string }{
+		{http.MethodGet, "/keys?project_id=" + projAlpha},
+		{http.MethodPost, "/keys"},
+		{http.MethodGet, "/settings/retention?project_id=" + projAlpha},
+		{http.MethodPatch, "/settings/retention"},
+		{http.MethodGet, "/metrics?project_id=" + projAlpha},
+		{http.MethodGet, "/projects"},
+		{http.MethodPost, "/projects"},
+		{http.MethodGet, "/projects/" + projAlpha},
+		{http.MethodPatch, "/projects/" + projAlpha},
+		{http.MethodDelete, "/projects/" + projAlpha},
+		{http.MethodGet, "/projects/" + projAlpha + "/members"},
+		{http.MethodPost, "/projects/" + projAlpha + "/members"},
+		{http.MethodDelete, "/projects/" + projAlpha + "/members/member-a"},
+		{http.MethodGet, "/projects/" + projAlpha + "/logs"},
+		{http.MethodPost, "/projects/" + projAlpha + "/logs"},
+		{http.MethodGet, "/projects/" + projAlpha + "/logs/" + alphaLogID},
+		{http.MethodDelete, "/projects/" + projAlpha + "/logs/" + alphaLogID},
+	}
+
+	for _, route := range routes {
+		r := internalRequest(route.method, route.target, "", nil)
+
+		if w := do(handler, r); w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s without X-User-Login: got %d, want 401", route.method, route.target, w.Code)
+		}
+	}
+}
+
+// --- membership enforcement ---
+
+func TestProjectRoutes_MembershipEnforced(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+
+	cases := []struct {
+		name       string
+		method     string
+		target     string
+		user       string
+		body       any
+		wantStatus int
+	}{
+		{"member reads own project", http.MethodGet, "/projects/" + projAlpha, "member-a", nil, http.StatusOK},
+		{"owner reads own project", http.MethodGet, "/projects/" + projAlpha, "owner-a", nil, http.StatusOK},
+		{"outsider reads project", http.MethodGet, "/projects/" + projAlpha, "stranger", nil, http.StatusForbidden},
+		{"other project's owner reads project", http.MethodGet, "/projects/" + projAlpha, "owner-b", nil, http.StatusForbidden},
+		{"unknown project is 404 not 403", http.MethodGet, "/projects/" + projMissing, "owner-a", nil, http.StatusNotFound},
+
+		{"member lists members", http.MethodGet, "/projects/" + projAlpha + "/members", "member-a", nil, http.StatusOK},
+		{"outsider lists members", http.MethodGet, "/projects/" + projAlpha + "/members", "owner-b", nil, http.StatusForbidden},
+
+		{"member lists logs", http.MethodGet, "/projects/" + projAlpha + "/logs", "member-a", nil, http.StatusOK},
+		{"outsider lists logs", http.MethodGet, "/projects/" + projAlpha + "/logs", "owner-b", nil, http.StatusForbidden},
+		{"outsider reads one log", http.MethodGet, "/projects/" + projAlpha + "/logs/" + alphaLogID, "owner-b", nil, http.StatusForbidden},
+		{"outsider deletes one log", http.MethodDelete, "/projects/" + projAlpha + "/logs/" + alphaLogID, "owner-b", nil, http.StatusForbidden},
+		// Rabbit is nil here, so anything past the membership check would panic
+		// rather than return 403 — reaching 403 is the assertion.
+		{"outsider writes a log", http.MethodPost, "/projects/" + projAlpha + "/logs", "owner-b", map[string]string{"name": "x"}, http.StatusForbidden},
+
+		{"outsider reads retention", http.MethodGet, "/settings/retention?project_id=" + projAlpha, "owner-b", nil, http.StatusForbidden},
+		{"member reads retention", http.MethodGet, "/settings/retention?project_id=" + projAlpha, "member-a", nil, http.StatusOK},
+		{"outsider writes retention", http.MethodPatch, "/settings/retention", "owner-b",
+			map[string]any{"project_id": projAlpha, "days": 30}, http.StatusForbidden},
+		{"member writes retention", http.MethodPatch, "/settings/retention", "member-a",
+			map[string]any{"project_id": projAlpha, "days": 30}, http.StatusOK},
+
+		{"outsider reads metrics", http.MethodGet, "/metrics?project_id=" + projAlpha, "owner-b", nil, http.StatusForbidden},
+		{"member reads metrics", http.MethodGet, "/metrics?project_id=" + projAlpha, "member-a", nil, http.StatusOK},
+
+		{"outsider lists keys", http.MethodGet, "/keys?project_id=" + projAlpha, "owner-b", nil, http.StatusForbidden},
+		{"outsider creates key", http.MethodPost, "/keys", "owner-b", map[string]string{"project_id": projAlpha}, http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := do(handler, internalRequest(tc.method, tc.target, tc.user, tc.body))
+			if w.Code != tc.wantStatus {
+				t.Errorf("%s %s as %q: got %d, want %d (body: %s)",
+					tc.method, tc.target, tc.user, w.Code, tc.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+// Project-scoped routes that need a project id must say so, rather than falling
+// back to some ambient default.
+func TestProjectScopedRoutes_RequireProjectID(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+
+	cases := []struct {
+		method string
+		target string
+		body   any
+	}{
+		{http.MethodGet, "/keys", nil},
+		{http.MethodPost, "/keys", map[string]string{}},
+		{http.MethodGet, "/settings/retention", nil},
+		{http.MethodPatch, "/settings/retention", map[string]any{"days": 30}},
+		{http.MethodGet, "/metrics", nil},
+	}
+
+	for _, tc := range cases {
+		w := do(handler, internalRequest(tc.method, tc.target, "owner-a", tc.body))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s %s without project_id: got %d, want 400", tc.method, tc.target, w.Code)
+		}
+	}
+}
+
+// --- owner-only operations ---
+
+func TestProjectRoutes_OwnerOnly(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		target string
+		body   any
+	}{
+		{"rename project", http.MethodPatch, "/projects/" + projAlpha, map[string]string{"name": "Renamed", "slug": "renamed"}},
+		{"delete project", http.MethodDelete, "/projects/" + projAlpha, nil},
+		{"add member", http.MethodPost, "/projects/" + projAlpha + "/members", map[string]string{"login": "newbie", "role": data.RoleMember}},
+		{"remove member", http.MethodDelete, "/projects/" + projAlpha + "/members/member-a", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" as member", func(t *testing.T) {
+			handler, _ := newInternalTestServer(t)
+			w := do(handler, internalRequest(tc.method, tc.target, "member-a", tc.body))
+			if w.Code != http.StatusForbidden {
+				t.Errorf("%s %s as member: got %d, want 403 (body: %s)", tc.method, tc.target, w.Code, w.Body.String())
+			}
+		})
+
+		t.Run(tc.name+" as outsider", func(t *testing.T) {
+			handler, _ := newInternalTestServer(t)
+			w := do(handler, internalRequest(tc.method, tc.target, "owner-b", tc.body))
+			if w.Code != http.StatusForbidden {
+				t.Errorf("%s %s as outsider: got %d, want 403 (body: %s)", tc.method, tc.target, w.Code, w.Body.String())
+			}
+		})
+
+		t.Run(tc.name+" as owner", func(t *testing.T) {
+			handler, _ := newInternalTestServer(t)
+			w := do(handler, internalRequest(tc.method, tc.target, "owner-a", tc.body))
+			if w.Code >= http.StatusBadRequest {
+				t.Errorf("%s %s as owner: got %d, want success (body: %s)", tc.method, tc.target, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// A member's failed write must not reach the logger at all — a 403 that still
+// forwarded the call would leave the project modified.
+func TestProjectRoutes_OwnerOnlyDeniesBeforeForwarding(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+
+	do(handler, internalRequest(http.MethodDelete, "/projects/"+projAlpha, "member-a", nil))
+	do(handler, internalRequest(http.MethodPatch, "/projects/"+projAlpha, "member-a",
+		map[string]string{"name": "Renamed", "slug": "renamed"}))
+	do(handler, internalRequest(http.MethodPost, "/projects/"+projAlpha+"/members", "member-a",
+		map[string]string{"login": "newbie", "role": data.RoleMember}))
+	do(handler, internalRequest(http.MethodDelete, "/projects/"+projAlpha+"/members/member-a", "member-a", nil))
+
+	fake.snapshot(func(f *fakeLogger) {
+		if len(f.deletedProjects) != 0 {
+			t.Errorf("DeleteProject forwarded for a non-owner: %v", f.deletedProjects)
+		}
+		if len(f.updatedProjects) != 0 {
+			t.Errorf("UpdateProject forwarded for a non-owner: %v", f.updatedProjects)
+		}
+		if len(f.addedMembers) != 0 {
+			t.Errorf("AddMember forwarded for a non-owner: %v", f.addedMembers)
+		}
+		if len(f.removedMembers) != 0 {
+			t.Errorf("RemoveMember forwarded for a non-owner: %v", f.removedMembers)
+		}
+	})
+}
+
+func TestRemoveProjectMember_LastOwnerIsBadRequest(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+	fake.lastOwnerLogin = "owner-a"
+
+	w := do(handler, internalRequest(http.MethodDelete, "/projects/"+projAlpha+"/members/owner-a", "owner-a", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("removing the last owner: got %d, want 400 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// --- project-scoped event access ---
+
+func TestProjectLogs_ScopedToPathProject(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+
+	w := do(handler, internalRequest(http.MethodGet, "/projects/"+projAlpha+"/logs", "member-a", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list logs: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	entries := decodeData[[]data.LogEntry](t, w)
+	for _, e := range entries {
+		if e.ProjectID != projAlpha {
+			t.Errorf("list logs returned an entry from project %q", e.ProjectID)
+		}
+		if e.Name == "beta-event" {
+			t.Error("list logs leaked project beta's event")
+		}
+	}
+
+	// The query the broker forwarded must be scoped to the path's project — the
+	// dashboard never gets to choose it.
+	fake.snapshot(func(f *fakeLogger) {
+		if len(f.getLogsParams) != 1 {
+			t.Fatalf("GetLogs called %d times, want 1", len(f.getLogsParams))
+		}
+		if f.getLogsParams[0].ProjectID != projAlpha {
+			t.Errorf("GetLogs ProjectID = %q, want %q", f.getLogsParams[0].ProjectID, projAlpha)
+		}
+	})
+}
+
+func TestProjectLogs_CrossProjectLogIDIsNotFound(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+
+	// owner-a knows beta's log id but has no access to it: the id names nothing
+	// inside alpha, so the answer is 404, not somebody else's event.
+	w := do(handler, internalRequest(http.MethodGet, "/projects/"+projAlpha+"/logs/"+betaLogID, "owner-a", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("read beta's log through alpha: got %d, want 404 (body: %s)", w.Code, w.Body.String())
+	}
+
+	w = do(handler, internalRequest(http.MethodDelete, "/projects/"+projAlpha+"/logs/"+betaLogID, "owner-a", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("delete beta's log through alpha: got %d, want 404 (body: %s)", w.Code, w.Body.String())
+	}
+
+	fake.snapshot(func(f *fakeLogger) {
+		if len(f.logs[projBeta]) != 1 {
+			t.Errorf("project beta lost %d log(s) to a cross-project delete", 1-len(f.logs[projBeta]))
+		}
+	})
+}
+
+func TestProjectLogs_OwnLogIsReadableAndDeletable(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+
+	w := do(handler, internalRequest(http.MethodGet, "/projects/"+projAlpha+"/logs/"+alphaLogID, "member-a", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("read own log: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	entry := decodeData[data.LogEntry](t, w)
+	if entry.ProjectID != projAlpha {
+		t.Errorf("entry ProjectID = %q, want %q", entry.ProjectID, projAlpha)
+	}
+
+	w = do(handler, internalRequest(http.MethodDelete, "/projects/"+projAlpha+"/logs/"+alphaLogID, "member-a", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete own log: got %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Deleting it twice is a miss, not a second success.
+	w = do(handler, internalRequest(http.MethodDelete, "/projects/"+projAlpha+"/logs/"+alphaLogID, "member-a", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("delete the same log again: got %d, want 404", w.Code)
+	}
+}
+
+// --- project listing and creation ---
+
+func TestListProjects_ScopedToCaller(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+
+	w := do(handler, internalRequest(http.MethodGet, "/projects", "member-a", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list projects: got %d, want 200", w.Code)
+	}
+
+	projects := decodeData[[]data.UserProject](t, w)
+	if len(projects) != 1 {
+		t.Fatalf("member-a sees %d project(s), want 1: %+v", len(projects), projects)
+	}
+	if projects[0].Slug != "alpha" {
+		t.Errorf("member-a sees project %q, want alpha", projects[0].Slug)
+	}
+	if projects[0].Role != data.RoleMember {
+		t.Errorf("member-a role = %q, want %q", projects[0].Role, data.RoleMember)
+	}
+
+	// A user with no memberships gets an empty list, not everyone's projects.
+	w = do(handler, internalRequest(http.MethodGet, "/projects", "stranger", nil))
+	if got := decodeData[[]data.UserProject](t, w); len(got) != 0 {
+		t.Errorf("stranger sees %d project(s), want 0: %+v", len(got), got)
+	}
+}
+
+func TestCreateProject_MakesCallerTheOwner(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+
+	w := do(handler, internalRequest(http.MethodPost, "/projects", "newcomer",
+		map[string]string{"name": "Fresh", "slug": "fresh"}))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create project: got %d, want 201 (body: %s)", w.Code, w.Body.String())
+	}
+	created := decodeData[data.Project](t, w)
+
+	fake.snapshot(func(f *fakeLogger) {
+		if len(f.addedMembers) != 1 {
+			t.Fatalf("AddMember called %d times, want 1", len(f.addedMembers))
+		}
+		got := f.addedMembers[0]
+		if got.GithubLogin != "newcomer" {
+			t.Errorf("owner login = %q, want %q", got.GithubLogin, "newcomer")
+		}
+		if got.Role != data.RoleOwner {
+			t.Errorf("owner role = %q, want %q", got.Role, data.RoleOwner)
+		}
+		if got.ProjectID != created.ID.Hex() {
+			t.Errorf("owner attached to project %q, want %q", got.ProjectID, created.ID.Hex())
+		}
+	})
+}
+
+func TestCreateProject_DuplicateSlugIsConflict(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+	fake.duplicateSlug = "alpha"
+
+	w := do(handler, internalRequest(http.MethodPost, "/projects", "newcomer",
+		map[string]string{"name": "Alpha again", "slug": "alpha"}))
+	if w.Code != http.StatusConflict {
+		t.Errorf("duplicate slug: got %d, want 409 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateProject_RejectsInvalidInput(t *testing.T) {
+	handler, _ := newInternalTestServer(t)
+
+	cases := []struct {
+		name string
+		body map[string]string
+	}{
+		{"missing name", map[string]string{"slug": "ok-slug"}},
+		{"invalid slug", map[string]string{"name": "X", "slug": "Not A Slug"}},
+		{"missing slug", map[string]string{"name": "X"}},
+	}
+
+	for _, tc := range cases {
+		w := do(handler, internalRequest(http.MethodPost, "/projects", "newcomer", tc.body))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: got %d, want 400", tc.name, w.Code)
+		}
+	}
+}
+
+// A project whose owner never got attached would be unreachable for everyone,
+// so the broker rolls the creation back.
+func TestCreateProject_RollsBackWhenOwnerCannotBeAttached(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+	fake.failAddMember = true
+
+	w := do(handler, internalRequest(http.MethodPost, "/projects", "newcomer",
+		map[string]string{"name": "Orphan", "slug": "orphan"}))
+	if w.Code < http.StatusBadRequest {
+		t.Fatalf("create project with failing AddMember: got %d, want an error status", w.Code)
+	}
+
+	fake.snapshot(func(f *fakeLogger) {
+		if len(f.deletedProjects) != 1 {
+			t.Fatalf("rollback deleted %d project(s), want 1", len(f.deletedProjects))
+		}
+		if _, stillThere := f.projects[f.deletedProjects[0]]; stillThere {
+			t.Error("rolled-back project is still present")
+		}
+	})
+}
+
+// --- retention and metrics carry the project through ---
+
+func TestRetentionAndMetrics_ForwardTheProjectID(t *testing.T) {
+	handler, fake := newInternalTestServer(t)
+
+	if w := do(handler, internalRequest(http.MethodPatch, "/settings/retention", "member-a",
+		map[string]any{"project_id": projAlpha, "days": 30})); w.Code != http.StatusOK {
+		t.Fatalf("update retention: got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if w := do(handler, internalRequest(http.MethodGet, "/metrics?project_id="+projAlpha, "member-a", nil)); w.Code != http.StatusOK {
+		t.Fatalf("get metrics: got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	fake.snapshot(func(f *fakeLogger) {
+		for _, args := range f.retentionArgs {
+			if args.ProjectID != projAlpha {
+				t.Errorf("retention call scoped to %q, want %q", args.ProjectID, projAlpha)
+			}
+		}
+		if len(f.retentionArgs) == 0 || f.retentionArgs[len(f.retentionArgs)-1].Days != 30 {
+			t.Errorf("retention days not forwarded: %+v", f.retentionArgs)
+		}
+		for _, args := range f.metricsArgs {
+			if args.ProjectID != projAlpha {
+				t.Errorf("metrics call scoped to %q, want %q", args.ProjectID, projAlpha)
+			}
+		}
+	})
+}

--- a/logwolf-server/integration/brokerclient_test.go
+++ b/logwolf-server/integration/brokerclient_test.go
@@ -1,0 +1,226 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// Helpers for driving the Broker over HTTP the way its two kinds of caller do:
+// an SDK client holding an API key, and the dashboard holding the internal
+// secret plus a GitHub login.
+
+// --- SDK routes (API key) ---
+
+// postLog sends a single log entry to the broker and asserts a 202 response.
+func postLog(t *testing.T, brokerURL, apiKey, name string) {
+	t.Helper()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":     name,
+		"data":     `{}`,
+		"severity": "info",
+		"tags":     []string{},
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, brokerURL+"/logs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("postLog %q: %v", name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("postLog %q: expected 202, got %d: %s", name, resp.StatusCode, b)
+	}
+}
+
+// getLogs calls GET /logs on the broker with the given API key and decodes the
+// log entry names from the response.
+func getLogs(t *testing.T, brokerURL, apiKey string) []string {
+	t.Helper()
+
+	req, _ := http.NewRequest(http.MethodGet, brokerURL+"/logs", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("getLogs: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("getLogs: expected 200, got %d: %s", resp.StatusCode, b)
+	}
+
+	var envelope struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("getLogs: decode: %v", err)
+	}
+
+	names := make([]string, 0, len(envelope.Data))
+	for _, e := range envelope.Data {
+		names = append(names, e.Name)
+	}
+	return names
+}
+
+// deleteLog sends DELETE /logs with the given log ID scoped to apiKey's project.
+func deleteLog(t *testing.T, brokerURL, apiKey, logID string) {
+	t.Helper()
+
+	deleteLogCount(t, brokerURL, apiKey, logID)
+}
+
+// deleteLogCount sends DELETE /logs and returns the number of entries deleted,
+// as reported by the broker in the response body.
+func deleteLogCount(t *testing.T, brokerURL, apiKey, logID string) int {
+	t.Helper()
+
+	body, _ := json.Marshal(map[string]string{"id": logID})
+	req, _ := http.NewRequest(http.MethodDelete, brokerURL+"/logs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("deleteLogCount: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("deleteLogCount: expected 202, got %d: %s", resp.StatusCode, b)
+	}
+
+	var envelope struct {
+		Data string `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("deleteLogCount: decode: %v", err)
+	}
+
+	var n int
+	fmt.Sscanf(envelope.Data, "Deleted entries: %d", &n)
+	return n
+}
+
+// --- internal routes (dashboard) ---
+
+// internalCall performs a dashboard-style request: internal secret plus the
+// GitHub login the broker checks project membership against. It returns the
+// status code and the decoded "data" member of the response envelope.
+func internalCall(t *testing.T, brokerURL, method, path, userLogin string, body any) (int, json.RawMessage) {
+	t.Helper()
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("internalCall %s %s: marshal body: %v", method, path, err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, brokerURL+path, reader)
+	if err != nil {
+		t.Fatalf("internalCall %s %s: %v", method, path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Secret", internalSecret)
+	req.Header.Set("X-User-Login", userLogin)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("internalCall %s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			t.Fatalf("internalCall %s %s: decode %q: %v", method, path, raw, err)
+		}
+	}
+
+	return resp.StatusCode, envelope.Data
+}
+
+// mustInternalCall is internalCall with the status asserted.
+func mustInternalCall(t *testing.T, brokerURL, method, path, userLogin string, body any, wantStatus int) json.RawMessage {
+	t.Helper()
+
+	status, data := internalCall(t, brokerURL, method, path, userLogin, body)
+	if status != wantStatus {
+		t.Fatalf("%s %s as %q: got %d, want %d (data: %s)", method, path, userLogin, status, wantStatus, data)
+	}
+	return data
+}
+
+// --- MongoDB polling ---
+
+// waitForLog polls MongoDB until a document with the given name appears.
+func waitForLog(t *testing.T, mongoURI, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+	coll := testMongo(t, mongoURI).Database("logs").Collection("logs")
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		count, _ := coll.CountDocuments(ctx, bson.M{"name": name})
+		if count > 0 {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	t.Fatalf("waitForLog: %q never appeared in MongoDB", name)
+}
+
+// fetchLogID reads the _id of the first log entry matching name directly from MongoDB.
+func fetchLogID(t *testing.T, mongoURI, name string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var doc struct {
+		ID primitive.ObjectID `bson:"_id"`
+	}
+	err := testMongo(t, mongoURI).Database("logs").Collection("logs").
+		FindOne(ctx, bson.M{"name": name}).Decode(&doc)
+	if err != nil {
+		t.Fatalf("fetchLogID: find %q: %v", name, err)
+	}
+
+	return doc.ID.Hex()
+}
+
+func containsName(names []string, target string) bool {
+	for _, n := range names {
+		if n == target {
+			return true
+		}
+	}
+	return false
+}

--- a/logwolf-server/integration/helpers_test.go
+++ b/logwolf-server/integration/helpers_test.go
@@ -3,66 +3,268 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/rabbitmq"
+	"github.com/testcontainers/testcontainers-go/wait"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/crypto/bcrypt"
 )
 
-const testProjectID = "integration"
+const (
+	testProjectID = "integration"
 
-// startStack launches Logger, Listener, and Broker as subprocesses pointed at
-// the test containers. It registers t.Cleanup to kill them on test exit.
-// Returns the Broker's base URL (e.g. "http://127.0.0.1:18080").
-func startStack(t *testing.T, mongoURI, rabbitURI string) string {
+	mongoUser = "admin"
+	mongoPass = "password"
+
+	// internalSecret is what the Broker is started with, so dashboard-style
+	// requests in these tests can reach the internal routes.
+	internalSecret = "test-secret"
+)
+
+// --- package-wide teardown ---
+
+var (
+	teardownMu sync.Mutex
+	teardowns  []func()
+)
+
+func onTeardown(fn func()) {
+	teardownMu.Lock()
+	defer teardownMu.Unlock()
+	teardowns = append(teardowns, fn)
+}
+
+// TestMain tears down the fixtures that outlive individual tests. Containers
+// and service processes are shared across the package rather than rebuilt per
+// test — standing a stack up costs the better part of a minute — so they cannot
+// hang off any one test's t.Cleanup.
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	teardownMu.Lock()
+	fns := teardowns
+	teardownMu.Unlock()
+
+	for i := len(fns) - 1; i >= 0; i-- {
+		fns[i]()
+	}
+
+	os.Exit(code)
+}
+
+// --- containers ---
+
+// startMongo launches a MongoDB container with the credentials the services
+// expect and returns its connection URI. The container lives until the package
+// finishes.
+func startMongo() (string, error) {
+	ctx := context.Background()
+
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mongo:4.2.16-bionic",
+			ExposedPorts: []string{"27017/tcp"},
+			Env: map[string]string{
+				"MONGO_INITDB_ROOT_USERNAME": mongoUser,
+				"MONGO_INITDB_ROOT_PASSWORD": mongoPass,
+			},
+			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	onTeardown(func() { c.Terminate(context.Background()) })
+
+	host, err := c.Host(ctx)
+	if err != nil {
+		return "", err
+	}
+	port, err := c.MappedPort(ctx, "27017")
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("mongodb://%s:%s@%s:%s", mongoUser, mongoPass, host, port.Port()), nil
+}
+
+func startRabbit() (string, error) {
+	ctx := context.Background()
+
+	c, err := rabbitmq.Run(ctx, "rabbitmq:3.9-alpine")
+	if err != nil {
+		return "", err
+	}
+	onTeardown(func() { c.Terminate(context.Background()) })
+
+	return c.AmqpURL(ctx)
+}
+
+// dedicatedMongo gives the caller a MongoDB container of its own, for tests
+// that cannot share a database with anything else.
+func dedicatedMongo(t *testing.T) string {
 	t.Helper()
 
-	loggerRPCAddr := freeAddr(t)
-	loggerHTTPAddr := freeAddr(t)
-	brokerHTTPAddr := freeAddr(t)
+	uri, err := startMongo()
+	if err != nil {
+		t.Fatalf("mongo container: %v", err)
+	}
+	return uri
+}
 
-	t.Logf("loggerRPCAddr=%s loggerHTTPAddr=%s brokerHTTPAddr=%s", loggerRPCAddr, loggerHTTPAddr, brokerHTTPAddr)
+// sharedModelsMongo is the MongoDB the data-layer tests share. They clear the
+// collections they use on setup, so one container serves all of them.
+var (
+	modelsMongoOnce sync.Once
+	modelsMongoURI  string
+	modelsMongoErr  error
+)
 
-	t.Log("starting Logger...")
-	startProcess(t, "../logger/cmd/api", map[string]string{
+func sharedModelsMongo(t *testing.T) string {
+	t.Helper()
+
+	modelsMongoOnce.Do(func() { modelsMongoURI, modelsMongoErr = startMongo() })
+	if modelsMongoErr != nil {
+		t.Fatalf("models mongo: %v", modelsMongoErr)
+	}
+	return modelsMongoURI
+}
+
+// --- shared service stack ---
+
+type testStack struct {
+	mongoURI  string
+	rabbitURI string
+	brokerURL string
+}
+
+var (
+	stackOnce sync.Once
+	stackVal  *testStack
+	stackErr  error
+)
+
+// sharedStack returns the one Logger/Listener/Broker stack the end-to-end tests
+// share. They stay out of each other's way by using distinct projects, which is
+// the property under test anyway.
+func sharedStack(t *testing.T) *testStack {
+	t.Helper()
+
+	stackOnce.Do(func() {
+		start := time.Now()
+		stackVal, stackErr = buildStack()
+		if stackErr == nil {
+			t.Logf("shared stack ready in %s (broker at %s)", time.Since(start).Round(time.Millisecond), stackVal.brokerURL)
+		}
+	})
+	if stackErr != nil {
+		t.Fatalf("shared stack: %v", stackErr)
+	}
+	return stackVal
+}
+
+func buildStack() (*testStack, error) {
+	mongoURI, err := startMongo()
+	if err != nil {
+		return nil, fmt.Errorf("mongo container: %w", err)
+	}
+
+	rabbitURI, err := startRabbit()
+	if err != nil {
+		return nil, fmt.Errorf("rabbitmq container: %w", err)
+	}
+
+	loggerRPCAddr, err := freeAddress()
+	if err != nil {
+		return nil, err
+	}
+	loggerHTTPAddr, err := freeAddress()
+	if err != nil {
+		return nil, err
+	}
+	brokerHTTPAddr, err := freeAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := spawn("../logger/cmd/api", map[string]string{
 		"MONGO_URL":        mongoURI,
 		"LOGGER_RPC_PORT":  portOf(loggerRPCAddr),
 		"LOGGER_HTTP_PORT": portOf(loggerHTTPAddr),
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("logger: %w", err)
+	}
+	if err := waitTCP(loggerRPCAddr, 60*time.Second); err != nil {
+		return nil, fmt.Errorf("logger RPC: %w", err)
+	}
 
-	t.Log("waiting for Logger RPC...")
-	waitForTCP(t, loggerRPCAddr, 30*time.Second)
-	t.Log("Logger RPC ready")
-
-	t.Log("starting Listener...")
-	startProcess(t, "../listener/cmd/api", map[string]string{
+	if err := spawn("../listener/cmd/api", map[string]string{
 		"RABBITMQ_URL":    rabbitURI,
 		"LOGGER_RPC_ADDR": loggerRPCAddr,
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("listener: %w", err)
+	}
 
-	t.Log("starting Broker...")
-	startProcess(t, "../broker/cmd/api", map[string]string{
+	if err := spawn("../broker/cmd/api", map[string]string{
 		"MONGO_URL":           mongoURI,
 		"RABBITMQ_URL":        rabbitURI,
 		"LOGGER_RPC_ADDR":     loggerRPCAddr,
 		"BROKER_PORT":         portOf(brokerHTTPAddr),
-		"INTERNAL_API_SECRET": "test-secret",
-	})
+		"INTERNAL_API_SECRET": internalSecret,
+	}); err != nil {
+		return nil, fmt.Errorf("broker: %w", err)
+	}
+	if err := waitHTTP("http://"+brokerHTTPAddr+"/ping", 60*time.Second); err != nil {
+		return nil, fmt.Errorf("broker HTTP: %w", err)
+	}
 
-	t.Log("waiting for Broker HTTP...")
-	waitForHTTP(t, "http://"+brokerHTTPAddr+"/ping", 30*time.Second)
-	t.Log("Broker HTTP ready")
+	if err := waitForPipeline(mongoURI, "http://"+brokerHTTPAddr, 60*time.Second); err != nil {
+		return nil, err
+	}
 
-	return "http://" + brokerHTTPAddr
+	return &testStack{
+		mongoURI:  mongoURI,
+		rabbitURI: rabbitURI,
+		brokerURL: "http://" + brokerHTTPAddr,
+	}, nil
+}
+
+// --- MongoDB clients ---
+
+func connectMongo(uri string) (*mongo.Client, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	return mongo.Connect(ctx, options.Client().ApplyURI(uri).
+		SetAuth(options.Credential{Username: mongoUser, Password: mongoPass}))
+}
+
+// testMongo returns a client for uri, disconnected when t finishes.
+func testMongo(t *testing.T, uri string) *mongo.Client {
+	t.Helper()
+
+	client, err := connectMongo(uri)
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	t.Cleanup(func() { client.Disconnect(context.Background()) })
+
+	return client
 }
 
 // testAPIKey seeds a valid API key directly into MongoDB and returns the plaintext.
@@ -70,45 +272,85 @@ func startStack(t *testing.T, mongoURI, rabbitURI string) string {
 func testAPIKey(t *testing.T, mongoURI string) string {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	return seedAPIKey(t, mongoURI, testProjectID, "lw_integrationtestkey0000000001")
+}
+
+// seedAPIKey inserts an API key scoped to projectID and returns the plaintext key.
+func seedAPIKey(t *testing.T, mongoURI, projectID, plaintext string) string {
+	t.Helper()
+
+	if err := insertAPIKey(mongoURI, projectID, plaintext); err != nil {
+		t.Fatalf("seedAPIKey: %v", err)
+	}
+	return plaintext
+}
+
+func insertAPIKey(mongoURI, projectID, plaintext string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI).
-		SetAuth(options.Credential{Username: "admin", Password: "password"}))
-	if err != nil {
-		t.Fatalf("testAPIKey: connect: %v", err)
-	}
-	t.Cleanup(func() { client.Disconnect(context.Background()) })
-
-	plaintext := "lw_integrationtestkey0000000001"
 	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
 	if err != nil {
-		t.Fatalf("testAPIKey: bcrypt: %v", err)
+		return fmt.Errorf("bcrypt: %w", err)
 	}
 
+	client, err := connectMongo(mongoURI)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer client.Disconnect(context.Background())
+
 	_, err = client.Database("logs").Collection("api_keys").InsertOne(ctx, bson.M{
-		"project_id": testProjectID,
+		"project_id": projectID,
 		"prefix":     plaintext[:10],
 		"hash":       string(hash),
 		"active":     true,
 		"created_at": time.Now(),
 	})
 	if err != nil {
-		t.Fatalf("testAPIKey: insert: %v", err)
+		return fmt.Errorf("insert: %w", err)
 	}
 
-	return plaintext
+	return nil
 }
 
-// --- internal helpers ---
+// --- processes ---
 
+// spawn runs a service as a subprocess for the rest of the package's life.
+// Output goes nowhere unless LOGWOLF_TEST_VERBOSE is set — a shared stack that
+// fails to come up takes every test with it, so the escape hatch is worth having.
+func spawn(pkgPath string, env map[string]string) error {
+	cmd := exec.Command("go", "run", pkgPath)
+	cmd.Env = append(os.Environ(), envSlice(env)...)
+
+	if os.Getenv("LOGWOLF_TEST_VERBOSE") != "" {
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s: %w", pkgPath, err)
+	}
+
+	onTeardown(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+
+	return nil
+}
+
+// startProcess is spawn scoped to a single test.
 func startProcess(t *testing.T, pkgPath string, env map[string]string) {
 	t.Helper()
 
 	cmd := exec.Command("go", "run", pkgPath)
 	cmd.Env = append(os.Environ(), envSlice(env)...)
-	// Leave Stdout and Stderr nil — os/exec will use os.DevNull directly,
-	// no pipes created, nothing to drain, cmd.Wait() returns immediately.
+
+	if os.Getenv("LOGWOLF_TEST_VERBOSE") != "" {
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+	}
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("startProcess %s: %v", pkgPath, err)
@@ -120,51 +362,125 @@ func startProcess(t *testing.T, pkgPath string, env map[string]string) {
 	})
 }
 
-func waitForTCP(t *testing.T, addr string, timeout time.Duration) {
-	t.Helper()
+// --- readiness ---
+
+func waitTCP(addr string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
 		if err == nil {
 			conn.Close()
-			return
+			return nil
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	t.Fatalf("waitForTCP: %s not ready after %s", addr, timeout)
+	return fmt.Errorf("%s not ready after %s", addr, timeout)
 }
 
-func waitForHTTP(t *testing.T, url string, timeout time.Duration) {
-	t.Helper()
+func waitHTTP(url string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		resp, err := http.Get(url)
-		if err == nil && resp.StatusCode == http.StatusOK {
-			return
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	t.Fatalf("waitForHTTP: %s not ready after %s", url, timeout)
+	return fmt.Errorf("%s not ready after %s", url, timeout)
+}
+
+// waitForPipeline publishes canary events until one comes back out of MongoDB.
+//
+// The Listener declares and binds the queue at its own pace after startup, and
+// a topic exchange drops what it has no binding for — so a Broker answering
+// /ping is not yet proof that an accepted event will be stored anywhere. Every
+// test that posts an event depends on this having happened, and there is no
+// endpoint that reports it, so the probe drives the real path instead.
+func waitForPipeline(mongoURI, brokerURL string, timeout time.Duration) error {
+	const (
+		canaryProject = "stack-canary"
+		canaryKey     = "lw_stackcanary000000001"
+		canaryEvent   = "stack-canary-event"
+	)
+
+	if err := insertAPIKey(mongoURI, canaryProject, canaryKey); err != nil {
+		return fmt.Errorf("pipeline probe: seed key: %w", err)
+	}
+
+	client, err := connectMongo(mongoURI)
+	if err != nil {
+		return fmt.Errorf("pipeline probe: connect: %w", err)
+	}
+	defer client.Disconnect(context.Background())
+
+	coll := client.Database("logs").Collection("logs")
+	body, _ := json.Marshal(map[string]any{
+		"name": canaryEvent, "data": "{}", "severity": "info", "tags": []string{},
+	})
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequest(http.MethodPost, brokerURL+"/logs", bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("pipeline probe: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+canaryKey)
+
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			resp.Body.Close()
+		}
+
+		// Give the event a moment to travel before publishing another.
+		for i := 0; i < 6 && time.Now().Before(deadline); i++ {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			n, err := coll.CountDocuments(ctx, bson.M{"name": canaryEvent})
+			cancel()
+			if err == nil && n > 0 {
+				return nil
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+
+	return fmt.Errorf("pipeline probe: no canary event reached MongoDB within %s", timeout)
+}
+
+func waitForTCP(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+	if err := waitTCP(addr, timeout); err != nil {
+		t.Fatalf("waitForTCP: %v", err)
+	}
+}
+
+// --- addresses ---
+
+func freeAddress() (string, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	defer l.Close()
+
+	return l.Addr().String(), nil
 }
 
 func freeAddr(t *testing.T) string {
 	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+
+	addr, err := freeAddress()
 	if err != nil {
 		t.Fatalf("freeAddr: %v", err)
 	}
-	addr := l.Addr().String()
-	l.Close()
 	return addr
 }
 
 func portOf(addr string) string {
 	_, port, _ := net.SplitHostPort(addr)
 	return port
-}
-
-func baseEnv() []string {
-	return os.Environ()
 }
 
 func envSlice(m map[string]string) []string {

--- a/logwolf-server/integration/project_cascade_test.go
+++ b/logwolf-server/integration/project_cascade_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// TestProjectDeleteCascade_EndToEnd builds a project the way the dashboard does
+// — create it, mint a key, set retention, send events through the SDK path —
+// then deletes it and checks that nothing of it survives in MongoDB.
+//
+// The data-layer cascade is covered by TestDeleteProject_Cascade; this one
+// exists because the delete has to reach that code through the Broker's
+// ownership check and the Logger RPC, and because the rows it must remove are
+// written here by the running services rather than seeded by the test.
+func TestProjectDeleteCascade_EndToEnd(t *testing.T) {
+	stack := sharedStack(t)
+	client := testMongo(t, stack.mongoURI)
+	db := client.Database("logs")
+
+	const owner = "cascade-owner"
+
+	// --- Create the project (the caller becomes its owner) ---
+
+	data := mustInternalCall(t, stack.brokerURL, http.MethodPost, "/projects", owner,
+		map[string]string{"name": "Cascade", "slug": "cascade"}, http.StatusCreated)
+
+	var project struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &project); err != nil {
+		t.Fatalf("decode created project: %v", err)
+	}
+	if project.ID == "" {
+		t.Fatalf("created project has no id: %s", data)
+	}
+
+	// --- Mint an API key for it ---
+
+	data = mustInternalCall(t, stack.brokerURL, http.MethodPost, "/keys", owner,
+		map[string]string{"project_id": project.ID}, http.StatusCreated)
+
+	var created struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(data, &created); err != nil {
+		t.Fatalf("decode created key: %v", err)
+	}
+	if created.Key == "" {
+		t.Fatalf("created key is empty: %s", data)
+	}
+
+	// --- Set retention, so a settings document exists ---
+
+	mustInternalCall(t, stack.brokerURL, http.MethodPatch, "/settings/retention", owner,
+		map[string]any{"project_id": project.ID, "days": 30}, http.StatusOK)
+
+	// --- Send events with that key ---
+
+	postLog(t, stack.brokerURL, created.Key, "cascade-event-1")
+	postLog(t, stack.brokerURL, created.Key, "cascade-event-2")
+	waitForLog(t, stack.mongoURI, "cascade-event-1")
+	waitForLog(t, stack.mongoURI, "cascade-event-2")
+
+	// --- Everything is in place before the delete ---
+
+	counts := map[string]func() int64{
+		"projects":        func() int64 { return countDocs(t, db.Collection("projects"), bson.M{"slug": "cascade"}) },
+		"project_members": func() int64 { return countDocs(t, db.Collection("project_members"), bson.M{"github_login": owner}) },
+		"api_keys":        func() int64 { return countDocs(t, db.Collection("api_keys"), bson.M{"project_id": project.ID}) },
+		"settings":        func() int64 { return countDocs(t, db.Collection("settings"), bson.M{"project_id": project.ID}) },
+		"logs":            func() int64 { return countDocs(t, db.Collection("logs"), bson.M{"project_id": project.ID}) },
+	}
+
+	for name, count := range counts {
+		if n := count(); n == 0 {
+			t.Fatalf("precondition: %s has no rows for the project, so its removal would prove nothing", name)
+		}
+	}
+
+	// --- Delete the project ---
+
+	mustInternalCall(t, stack.brokerURL, http.MethodDelete, "/projects/"+project.ID, owner, nil, http.StatusOK)
+
+	// The logs deletion is a DeleteMany the RPC waits on, so everything should
+	// already be gone; poll briefly rather than depend on that.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		clean := true
+		for _, count := range counts {
+			if count() != 0 {
+				clean = false
+				break
+			}
+		}
+		if clean {
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	for name, count := range counts {
+		if n := count(); n != 0 {
+			t.Errorf("after project delete: %s still holds %d row(s) for the project", name, n)
+		}
+	}
+
+	// --- The key it minted reads nothing back ---
+	//
+	// The Broker caches key lookups for 60s, so the key may still authenticate
+	// here. Either answer is acceptable — rejected outright, or accepted and
+	// scoped to a project that no longer has any events. What must not happen
+	// is events coming back.
+	req, _ := http.NewRequest(http.MethodGet, stack.brokerURL+"/logs", nil)
+	req.Header.Set("Authorization", "Bearer "+created.Key)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /logs with the deleted project's key: %v", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		// The key was revoked along with its project.
+	case http.StatusOK:
+		var envelope struct {
+			Data []json.RawMessage `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode GET /logs: %v", err)
+		}
+		if len(envelope.Data) != 0 {
+			t.Errorf("deleted project's key still reads %d event(s)", len(envelope.Data))
+		}
+	default:
+		t.Errorf("GET /logs with the deleted project's key: got %d, want 200 or 401", resp.StatusCode)
+	}
+
+	// --- Deleting it again is a 404, not a second success ---
+
+	status, _ := internalCall(t, stack.brokerURL, http.MethodDelete, "/projects/"+project.ID, owner, nil)
+	if status != http.StatusNotFound {
+		t.Errorf("deleting an already-deleted project: got %d, want 404", status)
+	}
+}
+
+func countDocs(t *testing.T, coll *mongo.Collection, filter bson.M) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	n, err := coll.CountDocuments(ctx, filter)
+	if err != nil {
+		t.Fatalf("count %s %v: %v", coll.Name(), filter, err)
+	}
+	return n
+}

--- a/logwolf-server/integration/project_crud_test.go
+++ b/logwolf-server/integration/project_crud_test.go
@@ -5,46 +5,33 @@ package integration
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+
 	"logwolf-toolbox/data"
 )
 
-// setupProjectModels spins up a throwaway MongoDB and returns a data.Models
-// with project indexes already created. Cleanup terminates the container.
+// setupProjectModels returns a data.Models backed by the MongoDB the data-layer
+// tests share, with the collections they touch cleared and the project indexes
+// recreated. One container serves every test in this file; a clean database per
+// test comes from the drop, not from a new container.
 func setupProjectModels(t *testing.T) data.Models {
 	t.Helper()
-	ctx := context.Background()
 
-	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mongo:4.2.16-bionic",
-			ExposedPorts: []string{"27017/tcp"},
-			WaitingFor:   wait.ForLog("waiting for connections on port 27017"),
-		},
-		Started: true,
-	})
-	if err != nil {
-		t.Fatalf("setupProjectModels: container start: %v", err)
+	client := testMongo(t, sharedModelsMongo(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, name := range []string{"projects", "project_members", "logs", "api_keys", "settings"} {
+		if err := client.Database("logs").Collection(name).Drop(ctx); err != nil {
+			t.Fatalf("setupProjectModels: drop %s: %v", name, err)
+		}
 	}
-	t.Cleanup(func() { mongoC.Terminate(ctx) })
-
-	host, _ := mongoC.Host(ctx)
-	port, _ := mongoC.MappedPort(ctx, "27017")
-	uri := fmt.Sprintf("mongodb://%s:%s", host, port.Port())
-
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
-	if err != nil {
-		t.Fatalf("setupProjectModels: connect: %v", err)
-	}
-	t.Cleanup(func() { client.Disconnect(ctx) })
 
 	m := data.New(client)
 	if err := m.EnsureProjectIndexes(); err != nil {
@@ -288,6 +275,56 @@ func TestRemoveProjectMember_NotFound(t *testing.T) {
 	err := m.RemoveProjectMember(p.ID, "ghost")
 	if !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Errorf("RemoveProjectMember missing: want mongo.ErrNoDocuments, got %v", err)
+	}
+}
+
+func TestGetProjectMembers(t *testing.T) {
+	m := setupProjectModels(t)
+
+	p, _ := m.InsertProject(data.Project{Name: "Listed", Slug: "listed"})
+	other, _ := m.InsertProject(data.Project{Name: "Other", Slug: "other"})
+
+	m.InsertProjectMember(data.ProjectMember{ProjectID: p.ID, GithubLogin: "erin", Role: data.RoleOwner})
+	m.InsertProjectMember(data.ProjectMember{ProjectID: p.ID, GithubLogin: "frank", Role: data.RoleMember})
+	m.InsertProjectMember(data.ProjectMember{ProjectID: other.ID, GithubLogin: "grace", Role: data.RoleOwner})
+
+	members, err := m.GetProjectMembers(p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectMembers: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("GetProjectMembers: want 2 members, got %d: %+v", len(members), members)
+	}
+
+	roles := map[string]string{}
+	for _, member := range members {
+		if member.ProjectID != p.ID {
+			t.Errorf("GetProjectMembers returned a member of project %s", member.ProjectID.Hex())
+		}
+		roles[member.GithubLogin] = member.Role
+	}
+	if roles["erin"] != data.RoleOwner {
+		t.Errorf("erin role = %q, want %q", roles["erin"], data.RoleOwner)
+	}
+	if roles["frank"] != data.RoleMember {
+		t.Errorf("frank role = %q, want %q", roles["frank"], data.RoleMember)
+	}
+	if _, leaked := roles["grace"]; leaked {
+		t.Error("GetProjectMembers leaked a member of another project")
+	}
+}
+
+func TestGetProjectMembers_NoMembers(t *testing.T) {
+	m := setupProjectModels(t)
+
+	p, _ := m.InsertProject(data.Project{Name: "Empty", Slug: "empty"})
+
+	members, err := m.GetProjectMembers(p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectMembers: %v", err)
+	}
+	if len(members) != 0 {
+		t.Errorf("GetProjectMembers on a memberless project: got %d", len(members))
 	}
 }
 

--- a/logwolf-server/integration/retention_cleanup_test.go
+++ b/logwolf-server/integration/retention_cleanup_test.go
@@ -4,16 +4,12 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // TestRetentionCleanup verifies that the logger's background cleanup goroutine
@@ -22,34 +18,11 @@ import (
 func TestRetentionCleanup(t *testing.T) {
 	ctx := context.Background()
 
-	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mongo:4.2.16-bionic",
-			ExposedPorts: []string{"27017/tcp"},
-			Env: map[string]string{
-				"MONGO_INITDB_ROOT_USERNAME": "admin",
-				"MONGO_INITDB_ROOT_PASSWORD": "password",
-			},
-			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
-		},
-		Started: true,
-	})
-	if err != nil {
-		t.Fatalf("mongo container: %v", err)
-	}
-	defer mongoC.Terminate(ctx)
-
-	mongoHost, _ := mongoC.Host(ctx)
-	mongoPort, _ := mongoC.MappedPort(ctx, "27017")
-	mongoURI := fmt.Sprintf("mongodb://admin:password@%s:%s", mongoHost, mongoPort.Port())
-
-	// Connect directly to MongoDB for seeding and assertions.
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI).
-		SetAuth(options.Credential{Username: "admin", Password: "password"}))
-	if err != nil {
-		t.Fatalf("mongo connect: %v", err)
-	}
-	t.Cleanup(func() { client.Disconnect(context.Background()) })
+	// A logger with a two-second cleanup interval runs against this database for
+	// the length of the test, so it gets a MongoDB of its own rather than
+	// deleting entries other tests are still asserting on.
+	mongoURI := dedicatedMongo(t)
+	client := testMongo(t, mongoURI)
 
 	db := client.Database("logs")
 
@@ -64,7 +37,7 @@ func TestRetentionCleanup(t *testing.T) {
 	projectBStr := projectB.Hex()
 
 	// Insert projects into the projects collection.
-	_, err = db.Collection("projects").InsertMany(ctx, []interface{}{
+	_, err := db.Collection("projects").InsertMany(ctx, []interface{}{
 		bson.M{"_id": projectA, "name": "Project A", "slug": "project-a", "created_at": time.Now()},
 		bson.M{"_id": projectB, "name": "Project B", "slug": "project-b", "created_at": time.Now()},
 	})

--- a/logwolf-server/integration/rpc_isolation_test.go
+++ b/logwolf-server/integration/rpc_isolation_test.go
@@ -3,189 +3,25 @@
 package integration
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"testing"
-	"time"
-
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/rabbitmq"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-	"golang.org/x/crypto/bcrypt"
 )
-
-// seedAPIKey inserts an API key scoped to projectID and returns the plaintext key.
-func seedAPIKey(t *testing.T, mongoURI, projectID, plaintext string) string {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI).
-		SetAuth(options.Credential{Username: "admin", Password: "password"}))
-	if err != nil {
-		t.Fatalf("seedAPIKey: connect: %v", err)
-	}
-	t.Cleanup(func() { client.Disconnect(context.Background()) })
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
-	if err != nil {
-		t.Fatalf("seedAPIKey: bcrypt: %v", err)
-	}
-
-	_, err = client.Database("logs").Collection("api_keys").InsertOne(ctx, bson.M{
-		"project_id": projectID,
-		"prefix":     plaintext[:10],
-		"hash":       string(hash),
-		"active":     true,
-		"created_at": time.Now(),
-	})
-	if err != nil {
-		t.Fatalf("seedAPIKey: insert: %v", err)
-	}
-
-	return plaintext
-}
-
-// postLog sends a single log entry to the broker and asserts a 202 response.
-func postLog(t *testing.T, brokerURL, apiKey, name string) {
-	t.Helper()
-
-	body, _ := json.Marshal(map[string]interface{}{
-		"name":     name,
-		"data":     `{}`,
-		"severity": "info",
-		"tags":     []string{},
-	})
-
-	req, _ := http.NewRequest(http.MethodPost, brokerURL+"/logs", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("postLog %q: %v", name, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusAccepted {
-		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("postLog %q: expected 202, got %d: %s", name, resp.StatusCode, b)
-	}
-}
-
-// waitForLog polls MongoDB until a document with the given name appears.
-func waitForLog(t *testing.T, mongoURI, name string) {
-	t.Helper()
-
-	ctx := context.Background()
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI).
-		SetAuth(options.Credential{Username: "admin", Password: "password"}))
-	if err != nil {
-		t.Fatalf("waitForLog: connect: %v", err)
-	}
-	defer client.Disconnect(ctx)
-
-	coll := client.Database("logs").Collection("logs")
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		count, _ := coll.CountDocuments(ctx, bson.M{"name": name})
-		if count > 0 {
-			return
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	t.Fatalf("waitForLog: %q never appeared in MongoDB", name)
-}
-
-// getLogs calls GET /logs on the broker with the given API key and decodes the
-// log entry names from the response.
-func getLogs(t *testing.T, brokerURL, apiKey string) []string {
-	t.Helper()
-
-	req, _ := http.NewRequest(http.MethodGet, brokerURL+"/logs", nil)
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("getLogs: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("getLogs: expected 200, got %d: %s", resp.StatusCode, b)
-	}
-
-	var envelope struct {
-		Data []struct {
-			Name string `json:"name"`
-		} `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		t.Fatalf("getLogs: decode: %v", err)
-	}
-
-	names := make([]string, 0, len(envelope.Data))
-	for _, e := range envelope.Data {
-		names = append(names, e.Name)
-	}
-	return names
-}
 
 // TestProjectIsolation_GetLogs verifies that logs written under project A are
 // not visible when querying as project B, and vice versa.
 func TestProjectIsolation_GetLogs(t *testing.T) {
-	ctx := context.Background()
+	stack := sharedStack(t)
 
-	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mongo:4.2.16-bionic",
-			ExposedPorts: []string{"27017/tcp"},
-			Env: map[string]string{
-				"MONGO_INITDB_ROOT_USERNAME": "admin",
-				"MONGO_INITDB_ROOT_PASSWORD": "password",
-			},
-			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
-		},
-		Started: true,
-	})
-	if err != nil {
-		t.Fatalf("mongo container: %v", err)
-	}
-	defer mongoC.Terminate(ctx)
+	keyA := seedAPIKey(t, stack.mongoURI, "project-alpha", "lw_alphakey0000000001")
+	keyB := seedAPIKey(t, stack.mongoURI, "project-beta0", "lw_betakey00000000001")
 
-	mongoHost, _ := mongoC.Host(ctx)
-	mongoPort, _ := mongoC.MappedPort(ctx, "27017")
-	mongoURI := fmt.Sprintf("mongodb://admin:password@%s:%s", mongoHost, mongoPort.Port())
+	postLog(t, stack.brokerURL, keyA, "alpha-event")
+	postLog(t, stack.brokerURL, keyB, "beta-event")
 
-	rabbitC, err := rabbitmq.Run(ctx, "rabbitmq:3.9-alpine")
-	if err != nil {
-		t.Fatalf("rabbitmq container: %v", err)
-	}
-	defer rabbitC.Terminate(ctx)
-
-	rabbitURI, _ := rabbitC.AmqpURL(ctx)
-
-	brokerURL := startStack(t, mongoURI, rabbitURI)
-
-	keyA := seedAPIKey(t, mongoURI, "project-alpha", "lw_alphakey0000000001")
-	keyB := seedAPIKey(t, mongoURI, "project-beta0", "lw_betakey00000000001")
-
-	postLog(t, brokerURL, keyA, "alpha-event")
-	postLog(t, brokerURL, keyB, "beta-event")
-
-	waitForLog(t, mongoURI, "alpha-event")
-	waitForLog(t, mongoURI, "beta-event")
+	waitForLog(t, stack.mongoURI, "alpha-event")
+	waitForLog(t, stack.mongoURI, "beta-event")
 
 	// Project A should see its own log and not project B's.
-	logsA := getLogs(t, brokerURL, keyA)
+	logsA := getLogs(t, stack.brokerURL, keyA)
 	t.Logf("project-alpha logs: %v", logsA)
 
 	if !containsName(logsA, "alpha-event") {
@@ -196,7 +32,7 @@ func TestProjectIsolation_GetLogs(t *testing.T) {
 	}
 
 	// Project B should see its own log and not project A's.
-	logsB := getLogs(t, brokerURL, keyB)
+	logsB := getLogs(t, stack.brokerURL, keyB)
 	t.Logf("project-beta logs: %v", logsB)
 
 	if !containsName(logsB, "beta-event") {
@@ -210,62 +46,31 @@ func TestProjectIsolation_GetLogs(t *testing.T) {
 // TestProjectIsolation_DeleteLog verifies that a DELETE /logs request scoped to
 // project A does not remove logs belonging to project B.
 func TestProjectIsolation_DeleteLog(t *testing.T) {
-	ctx := context.Background()
+	stack := sharedStack(t)
 
-	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mongo:4.2.16-bionic",
-			ExposedPorts: []string{"27017/tcp"},
-			Env: map[string]string{
-				"MONGO_INITDB_ROOT_USERNAME": "admin",
-				"MONGO_INITDB_ROOT_PASSWORD": "password",
-			},
-			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
-		},
-		Started: true,
-	})
-	if err != nil {
-		t.Fatalf("mongo container: %v", err)
-	}
-	defer mongoC.Terminate(ctx)
+	keyA := seedAPIKey(t, stack.mongoURI, "del-alpha", "lw_delalpha0000000001")
+	keyB := seedAPIKey(t, stack.mongoURI, "del-beta00", "lw_delbeta00000000001")
 
-	mongoHost, _ := mongoC.Host(ctx)
-	mongoPort, _ := mongoC.MappedPort(ctx, "27017")
-	mongoURI := fmt.Sprintf("mongodb://admin:password@%s:%s", mongoHost, mongoPort.Port())
+	postLog(t, stack.brokerURL, keyA, "del-alpha-event")
+	postLog(t, stack.brokerURL, keyB, "del-beta-event")
 
-	rabbitC, err := rabbitmq.Run(ctx, "rabbitmq:3.9-alpine")
-	if err != nil {
-		t.Fatalf("rabbitmq container: %v", err)
-	}
-	defer rabbitC.Terminate(ctx)
-
-	rabbitURI, _ := rabbitC.AmqpURL(ctx)
-
-	brokerURL := startStack(t, mongoURI, rabbitURI)
-
-	keyA := seedAPIKey(t, mongoURI, "del-alpha", "lw_delalpha0000000001")
-	keyB := seedAPIKey(t, mongoURI, "del-beta00", "lw_delbeta00000000001")
-
-	postLog(t, brokerURL, keyA, "del-alpha-event")
-	postLog(t, brokerURL, keyB, "del-beta-event")
-
-	waitForLog(t, mongoURI, "del-alpha-event")
-	waitForLog(t, mongoURI, "del-beta-event")
+	waitForLog(t, stack.mongoURI, "del-alpha-event")
+	waitForLog(t, stack.mongoURI, "del-beta-event")
 
 	// Fetch project A's log ID so we can target it for deletion.
-	logIDA := fetchLogID(t, mongoURI, "del-alpha-event")
+	logIDA := fetchLogID(t, stack.mongoURI, "del-alpha-event")
 
 	// Delete the log as project A.
-	deleteLog(t, brokerURL, keyA, logIDA)
+	deleteLog(t, stack.brokerURL, keyA, logIDA)
 
 	// Project A's log must be gone.
-	logsA := getLogs(t, brokerURL, keyA)
+	logsA := getLogs(t, stack.brokerURL, keyA)
 	if containsName(logsA, "del-alpha-event") {
 		t.Error("del-alpha-event should have been deleted but is still present")
 	}
 
 	// Project B's log must be unaffected.
-	logsB := getLogs(t, brokerURL, keyB)
+	logsB := getLogs(t, stack.brokerURL, keyB)
 	if !containsName(logsB, "del-beta-event") {
 		t.Error("del-beta-event was deleted but should not have been")
 	}
@@ -276,146 +81,43 @@ func TestProjectIsolation_DeleteLog(t *testing.T) {
 // The broker sets project_id from the authenticated key, so the DB filter
 // (id=B_id AND project_id=A) matches nothing and returns 0 deleted.
 func TestProjectIsolation_CrossDelete(t *testing.T) {
-	ctx := context.Background()
+	stack := sharedStack(t)
 
-	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mongo:4.2.16-bionic",
-			ExposedPorts: []string{"27017/tcp"},
-			Env: map[string]string{
-				"MONGO_INITDB_ROOT_USERNAME": "admin",
-				"MONGO_INITDB_ROOT_PASSWORD": "password",
-			},
-			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
-		},
-		Started: true,
-	})
-	if err != nil {
-		t.Fatalf("mongo container: %v", err)
-	}
-	defer mongoC.Terminate(ctx)
+	keyA := seedAPIKey(t, stack.mongoURI, "xdel-alpha", "lw_xdelattempt000001")
+	keyB := seedAPIKey(t, stack.mongoURI, "xdel-beta0", "lw_xdelvictim000001")
 
-	mongoHost, _ := mongoC.Host(ctx)
-	mongoPort, _ := mongoC.MappedPort(ctx, "27017")
-	mongoURI := fmt.Sprintf("mongodb://admin:password@%s:%s", mongoHost, mongoPort.Port())
+	postLog(t, stack.brokerURL, keyB, "xdel-victim-event")
+	waitForLog(t, stack.mongoURI, "xdel-victim-event")
 
-	rabbitC, err := rabbitmq.Run(ctx, "rabbitmq:3.9-alpine")
-	if err != nil {
-		t.Fatalf("rabbitmq container: %v", err)
-	}
-	defer rabbitC.Terminate(ctx)
-
-	rabbitURI, _ := rabbitC.AmqpURL(ctx)
-
-	brokerURL := startStack(t, mongoURI, rabbitURI)
-
-	keyA := seedAPIKey(t, mongoURI, "xdel-alpha", "lw_xdelattempt000001")
-	keyB := seedAPIKey(t, mongoURI, "xdel-beta0", "lw_xdelvictim000001")
-
-	postLog(t, brokerURL, keyB, "xdel-victim-event")
-	waitForLog(t, mongoURI, "xdel-victim-event")
-
-	logIDB := fetchLogID(t, mongoURI, "xdel-victim-event")
+	logIDB := fetchLogID(t, stack.mongoURI, "xdel-victim-event")
 
 	// Project A attempts to delete project B's log ID. The broker will scope
 	// the filter to project A, so the document is never matched.
-	n := deleteLogCount(t, brokerURL, keyA, logIDB)
+	n := deleteLogCount(t, stack.brokerURL, keyA, logIDB)
 	if n != 0 {
 		t.Errorf("cross-project delete: expected 0 deleted, got %d", n)
 	}
 
 	// Project B's log must still be present.
-	logsB := getLogs(t, brokerURL, keyB)
+	logsB := getLogs(t, stack.brokerURL, keyB)
 	if !containsName(logsB, "xdel-victim-event") {
 		t.Error("cross-project delete: victim log was removed but should not have been")
 	}
 }
 
-// --- helpers ---
+// TestProjectIsolation_CrossReadByID verifies that a key for project A cannot
+// read project B's entry even when it knows the id: GET /logs is scoped to the
+// key's project, so B's entry is simply not in the result.
+func TestProjectIsolation_CrossReadByID(t *testing.T) {
+	stack := sharedStack(t)
 
-func containsName(names []string, target string) bool {
-	for _, n := range names {
-		if n == target {
-			return true
-		}
-	}
-	return false
-}
+	keyA := seedAPIKey(t, stack.mongoURI, "xread-alpha", "lw_xreadalpha000001")
+	keyB := seedAPIKey(t, stack.mongoURI, "xread-beta0", "lw_xreadbeta0000001")
 
-// fetchLogID reads the _id of the first log entry matching name directly from MongoDB.
-func fetchLogID(t *testing.T, mongoURI, name string) string {
-	t.Helper()
+	postLog(t, stack.brokerURL, keyB, "xread-private-event")
+	waitForLog(t, stack.mongoURI, "xread-private-event")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI).
-		SetAuth(options.Credential{Username: "admin", Password: "password"}))
-	if err != nil {
-		t.Fatalf("fetchLogID: connect: %v", err)
-	}
-	defer client.Disconnect(ctx)
-
-	var doc struct {
-		ID primitive.ObjectID `bson:"_id"`
-	}
-	err = client.Database("logs").Collection("logs").
-		FindOne(ctx, bson.M{"name": name}).Decode(&doc)
-	if err != nil {
-		t.Fatalf("fetchLogID: find %q: %v", name, err)
-	}
-
-	return doc.ID.Hex()
-}
-
-// deleteLogCount sends DELETE /logs and returns the number of entries deleted,
-// as reported by the broker in the response body.
-func deleteLogCount(t *testing.T, brokerURL, apiKey, logID string) int {
-	t.Helper()
-
-	body, _ := json.Marshal(map[string]string{"id": logID})
-	req, _ := http.NewRequest(http.MethodDelete, brokerURL+"/logs", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("deleteLogCount: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusAccepted {
-		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("deleteLogCount: expected 202, got %d: %s", resp.StatusCode, b)
-	}
-
-	var envelope struct {
-		Data string `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		t.Fatalf("deleteLogCount: decode: %v", err)
-	}
-
-	var n int
-	fmt.Sscanf(envelope.Data, "Deleted entries: %d", &n)
-	return n
-}
-
-// deleteLog sends DELETE /logs with the given log ID scoped to apiKey's project.
-func deleteLog(t *testing.T, brokerURL, apiKey, logID string) {
-	t.Helper()
-
-	body, _ := json.Marshal(map[string]string{"id": logID})
-	req, _ := http.NewRequest(http.MethodDelete, brokerURL+"/logs", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("deleteLog: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusAccepted {
-		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("deleteLog: expected 202, got %d: %s", resp.StatusCode, b)
+	if names := getLogs(t, stack.brokerURL, keyA); containsName(names, "xread-private-event") {
+		t.Errorf("project xread-alpha can read xread-beta0's entry: %v", names)
 	}
 }

--- a/logwolf-server/integration/write_path_test.go
+++ b/logwolf-server/integration/write_path_test.go
@@ -6,69 +6,23 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/rabbitmq"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// TestWritePathRoundTrip drives an event through the whole write path —
+// Broker HTTP, RabbitMQ, Listener, Logger RPC, MongoDB — and checks that it
+// lands under the project the API key belongs to.
 func TestWritePathRoundTrip(t *testing.T) {
 	ctx := context.Background()
 
-	// --- Start containers ---
-	mongoC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mongo:4.2.16-bionic",
-			ExposedPorts: []string{"27017/tcp"},
-			Env: map[string]string{
-				"MONGO_INITDB_ROOT_USERNAME": "admin",
-				"MONGO_INITDB_ROOT_PASSWORD": "password",
-			},
-			WaitingFor: wait.ForLog("waiting for connections on port 27017"),
-		},
-		Started: true,
-	})
-	if err != nil {
-		t.Fatalf("mongo container: %v", err)
-	}
-	defer mongoC.Terminate(ctx)
+	stack := sharedStack(t)
+	apiKey := testAPIKey(t, stack.mongoURI)
 
-	mongoHost, _ := mongoC.Host(ctx)
-	mongoPort, _ := mongoC.MappedPort(ctx, "27017")
-	mongoURI := fmt.Sprintf("mongodb://admin:password@%s:%s", mongoHost, mongoPort.Port())
-
-	rabbitC, err := rabbitmq.Run(ctx, "rabbitmq:3.9-alpine")
-	if err != nil {
-		t.Fatalf("rabbitmq container: %v", err)
-	}
-	defer rabbitC.Terminate(ctx)
-
-	rabbitURI, _ := rabbitC.AmqpURL(ctx)
-
-	// --- Start Logger, Listener, Broker in-process (using env vars) ---
-	// Wire up the stack pointing at test containers, then POST a log entry
-	// and poll MongoDB until it appears.
-	//
-	// In practice the three services are separate binaries, so this test
-	// invokes them as subprocesses with environment overrides, or you extract
-	// the wiring into testable packages. The simplest approach that matches
-	// the existing architecture: run the stack via docker-compose with
-	// overridden env vars and drive it via HTTP.
-	//
-	// Here we use direct Mongo polling as the assertion — no need to go
-	// through the Broker GET /logs endpoint for the round-trip assertion.
-
-	brokerURL := startStack(t, mongoURI, rabbitURI)
-
-	// --- POST a log entry via Broker HTTP ---
 	payload := map[string]interface{}{
 		"name":     "integration-test-event",
 		"data":     `{"test":true}`,
@@ -77,42 +31,30 @@ func TestWritePathRoundTrip(t *testing.T) {
 	}
 	body, _ := json.Marshal(payload)
 
-	req, _ := http.NewRequest(http.MethodPost, brokerURL+"/logs", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, stack.brokerURL+"/logs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+testAPIKey(t, mongoURI))
+	req.Header.Set("Authorization", "Bearer "+apiKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("POST /logs: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
-		t.Fatalf("expected 202, got %d", resp.StatusCode)
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /logs: expected 202, got %d: %s", resp.StatusCode, respBody)
 	}
 
-	// --- Verify POST response body for early diagnosis ---
-	respBody, _ := io.ReadAll(resp.Body)
-	t.Logf("POST /logs response: %s", string(respBody))
+	collection := testMongo(t, stack.mongoURI).Database("logs").Collection("logs")
 
-	// --- Poll MongoDB with progress logging ---
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI).
-		SetAuth(options.Credential{Username: "admin", Password: "password"}))
-	if err != nil {
-		t.Fatalf("mongo connect: %v", err)
-	}
-	defer client.Disconnect(ctx)
-
-	collection := client.Database("logs").Collection("logs")
-	deadline := time.Now().Add(10 * time.Second)
-	attempt := 0
-
+	// Delivery is asynchronous, so poll until the entry shows up.
+	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
-		attempt++
 		count, err := collection.CountDocuments(ctx, bson.M{"name": "integration-test-event"})
-		t.Logf("attempt %d: count=%d err=%v", attempt, count, err)
 		if err == nil && count > 0 {
 			break
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(300 * time.Millisecond)
 	}
 
 	var doc struct {
@@ -124,5 +66,74 @@ func TestWritePathRoundTrip(t *testing.T) {
 	}
 	if doc.ProjectID != testProjectID {
 		t.Errorf("project_id = %q, want %q", doc.ProjectID, testProjectID)
+	}
+}
+
+// TestWritePathBatch_ScopedToKeysProject covers the batch endpoint and the
+// property that makes it safe to expose: the project comes from the API key,
+// so a caller cannot file events against a project it has no key for.
+func TestWritePathBatch_ScopedToKeysProject(t *testing.T) {
+	ctx := context.Background()
+
+	stack := sharedStack(t)
+	apiKey := seedAPIKey(t, stack.mongoURI, "batch-project", "lw_batchkey0000000001")
+
+	batch := []map[string]interface{}{
+		{"name": "batch-event-1", "data": "{}", "severity": "info", "tags": []string{}},
+		{"name": "batch-event-2", "data": "{}", "severity": "warning", "tags": []string{}},
+		// This one claims to belong somewhere else. The Broker overwrites the
+		// field with the key's project rather than trusting the body.
+		{"name": "batch-event-3", "data": "{}", "severity": "error", "tags": []string{}, "project_id": "victim-project"},
+	}
+	body, _ := json.Marshal(batch)
+
+	req, _ := http.NewRequest(http.MethodPost, stack.brokerURL+"/logs/batch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /logs/batch: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /logs/batch: expected 202, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	coll := testMongo(t, stack.mongoURI).Database("logs").Collection("logs")
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		count, err := coll.CountDocuments(ctx, bson.M{"project_id": "batch-project"})
+		if err == nil && count == int64(len(batch)) {
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	count, err := coll.CountDocuments(ctx, bson.M{"project_id": "batch-project"})
+	if err != nil {
+		t.Fatalf("count batch entries: %v", err)
+	}
+	if count != int64(len(batch)) {
+		t.Errorf("batch landed %d entr(ies) under batch-project, want %d", count, len(batch))
+	}
+
+	// The forged project_id must not have created anything.
+	stray, err := coll.CountDocuments(ctx, bson.M{"project_id": "victim-project"})
+	if err != nil {
+		t.Fatalf("count forged entries: %v", err)
+	}
+	if stray != 0 {
+		t.Errorf("body-supplied project_id was honoured: %d entr(ies) landed under victim-project", stray)
+	}
+
+	// And the key reads back exactly its own events.
+	names := getLogs(t, stack.brokerURL, apiKey)
+	for _, want := range []string{"batch-event-1", "batch-event-2", "batch-event-3"} {
+		if !containsName(names, want) {
+			t.Errorf("GET /logs did not return %q: %v", want, names)
+		}
 	}
 }

--- a/logwolf-server/logger/docs/OVERVIEW.md
+++ b/logwolf-server/logger/docs/OVERVIEW.md
@@ -74,6 +74,19 @@ The HTTP server has a 15-second shutdown timeout. The RPC server closes its TCP 
 | `logwolf-toolbox`  | Shared data models and utilities    |
 | `net/rpc` (stdlib) | RPC server (no external dependency) |
 
+## Development
+
+```bash
+# Run locally
+cd logwolf-server/logger && go run ./cmd/api
+
+# Unit tests
+cd logwolf-server/logger && go test ./... -v
+```
+
+The project-scoped RPC methods are covered end to end by the integration suite
+(`logwolf-server/integration`), which runs the real Logger against MongoDB.
+
 ## Relationship to other services
 
 | Service  | Relationship                                                  |


### PR DESCRIPTION
Closes #19.

Three of the issue's boxes were already ticked by earlier phases — the isolation test, the data-layer cascade test, and the retention-cleanup test all existed. The real gaps were the broker's membership middleware and an end-to-end cascade.

## Broker unit tests

`X-User-Login` / membership enforcement had no coverage at all. The project handlers dial the Logger themselves via `LOGGER_RPC_ADDR`, so there was no seam for a mock: `fakelogger_test.go` puts a real `net/rpc` server on the other end of that dial instead, which keeps the wire contract intact — including net/rpc flattening errors into strings, which the broker matches on for `E11000` and "last owner".

`project_access_test.go` then drives the real router:

- internal-secret and `X-User-Login` rejection across all 17 internal routes
- non-member `403` vs. unknown-project `404`
- owner-only guards, including asserting the denied call never reaches the logger
- cross-project log ids returning `404`, and `GET /projects/{id}/logs` forwarding the path's project
- create-project owner assignment, duplicate-slug `409`, and the rollback when the owner cannot be attached

Broker suite: 9 → 58 passing assertions.

## Integration

- `project_cascade_test.go` builds a project the way the dashboard does — create, mint key, set retention, send events — then deletes it and checks all five collections are clear, that the minted key reads nothing back, and that a second delete is a `404`.
- `TestWritePathRoundTrip` gained a batch case proving a forged `project_id` in the body is overwritten by the key's project.
- Added a cross-read isolation case and `GetProjectMembers` coverage.

## Two things found along the way

**The suite didn't fit CI's budget.** Baseline was 252s against a 300s timeout, because every test built its own containers and stack. The fixtures are now shared (`sharedStack`, `sharedModelsMongo`, teardown via `TestMain`): **252s → 71s**, with four more tests than before.

**A latent startup race.** The Listener declares and binds the queue at its own pace, and a topic exchange silently drops what it cannot route — so a Broker answering `/ping` was never proof that an accepted event would be stored. This bit during a slow post-recompile startup: events vanished. `waitForPipeline` now publishes canaries until one comes back out of MongoDB before any test runs.

**Also:** `logwolf-server/logger` has unit tests that CI never ran. Added to the workflow; CLAUDE.md and the logger OVERVIEW updated to match.

## Verification

All four suites green. Mutation-tested rather than trusted green: removing the four owner-only guards fails exactly the 5 expected broker tests, and breaking the api_keys/settings cascade fails both cascade tests with precise messages.

No production source changed — the diff is tests, CI, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)